### PR TITLE
update early neonatal lri duration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     # use "pip install -e .[dev]" to install required components + extra components
     internal = [
         'vivarium_inputs[data]==4.0.4',
-        'vivarium_cluster_tools==1.2.4',
+        'vivarium_cluster_tools>=1.2.5',
     ]
 
     interactive = [

--- a/src/vivarium_ciff_sam/constants/data_values.py
+++ b/src/vivarium_ciff_sam/constants/data_values.py
@@ -4,6 +4,8 @@
 
 # LRI duration in days
 LRI_DURATION: int = 10
+# lri_duration > bin_duration, so there is effectively no remission, and duration within the bin is bin_duration / 2
+EARLY_NEONATAL_LRI_DURATION: float = 3.5
 
 
 ############################

--- a/src/vivarium_ciff_sam/data/loader.py
+++ b/src/vivarium_ciff_sam/data/loader.py
@@ -158,7 +158,11 @@ def get_entity(key: str):
 def load_lri_prevalence(key: str, location: str) -> pd.DataFrame:
     if key == data_keys.LRI.PREVALENCE:
         incidence_rate = get_data(data_keys.LRI.INCIDENCE_RATE, location)
-        prevalence = incidence_rate * data_values.LRI_DURATION / 365
+        early_neonatal_prevalence = (incidence_rate[incidence_rate.index.get_level_values('age_start') == 0.0]
+                                     * data_values.EARLY_NEONATAL_LRI_DURATION / 365)
+        all_other_prevalence = (incidence_rate[incidence_rate.index.get_level_values('age_start') != 0.0]
+                                * data_values.LRI_DURATION / 365)
+        prevalence = pd.concat([early_neonatal_prevalence, all_other_prevalence])
         return prevalence
     else:
         raise ValueError(f'Unrecognized key {key}')

--- a/src/vivarium_ciff_sam/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/branches/scenarios.yaml
@@ -1,5 +1,5 @@
 input_draw_count: 12
-random_seed_count: 10
+random_seed_count: 100
 
 branches:
   - intervention:

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -46,7 +46,7 @@ configuration:
             day: 31
         step_size: 0.5 # Days
     population:
-        population_size: 100000
+        population_size: 10000
         age_start: 0
         age_end: 5
 


### PR DESCRIPTION
Updated the pin for cluster tools
Changed the population size - seed count split to maintain the total number of simulants, but speed up the simulation ~3-fold
Updated the duration of LRI in the early neo-natal age group to 3.5 days to account for the fact that the LRI duration (10 days) is longer than the duration of the age bin