### PR TITLE
allow make_artifacts to specify keys to overwrite

### DIFF
--- a/src/vivarium_ciff_sam/data/builder.py
+++ b/src/vivarium_ciff_sam/data/builder.py
@@ -48,7 +48,7 @@ def open_artifact(output_path: Path, location: str) -> Artifact:
     return artifact
 
 
-def load_and_write_data(artifact: Artifact, key: str, location: str):
+def load_and_write_data(artifact: Artifact, key: str, location: str, replace: bool):
     """Loads data and writes it to the artifact if not already present.
 
     Parameters
@@ -60,15 +60,21 @@ def load_and_write_data(artifact: Artifact, key: str, location: str):
     location
         The location associated with the data to load and the artifact to
         write to.
+    replace
+        Flag which determines whether or not to overwrite existing data
 
     """
-    if key in artifact:
+    if key in artifact and not replace:
         logger.debug(f'Data for {key} already in artifact.  Skipping...')
     else:
         logger.debug(f'Loading data for {key} for location {location}.')
         data = loader.get_data(key, location)
-        logger.debug(f'Writing data for {key} to artifact.')
-        artifact.write(key, data)
+        if key not in artifact:
+            logger.debug(f'Writing data for {key} to artifact.')
+            artifact.write(key, data)
+        else:   # key is in artifact, but should be replaced
+            logger.debug(f'Replacing data for {key} in artifact.')
+            artifact.replace(key, data)
     return artifact.load(key)
 
 
@@ -91,6 +97,7 @@ def write_data(artifact: Artifact, key: str, data: pd.DataFrame):
         logger.debug(f'Writing data for {key} to artifact.')
         artifact.write(key, data)
     return artifact.load(key)
+
 
 # TODO - writing and reading by draw is necessary if you are using
 #        LBWSG data. Find the read function in utilities.py

--- a/src/vivarium_ciff_sam/tools/cli.py
+++ b/src/vivarium_ciff_sam/tools/cli.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import click
 from loguru import logger
 from vivarium.framework.utilities import handle_exceptions
@@ -22,16 +24,20 @@ from vivarium_ciff_sam.tools import build_artifacts, build_results, configure_lo
 @click.option('-a', '--append',
               is_flag=True,
               help='Append to the artifact instead of overwriting.')
+@click.option('-r', '--replace-keys',
+              multiple=True,
+              help='Specify keys to overwrite')
 @click.option('-v', 'verbose',
               count=True,
               help='Configure logging verbosity.')
 @click.option('--pdb', 'with_debugger',
               is_flag=True,
               help='Drop into python debugger if an error occurs.')
-def make_artifacts(location: str, output_dir: str, append: bool, verbose: int, with_debugger: bool) -> None:
+def make_artifacts(location: str, output_dir: str, append: bool, replace_keys: Tuple[str, ...],
+                   verbose: int, with_debugger: bool) -> None:
     configure_logging_to_terminal(verbose)
     main = handle_exceptions(build_artifacts, logger, with_debugger=with_debugger)
-    main(location, output_dir, append, verbose)
+    main(location, output_dir, append, replace_keys, verbose)
 
 
 @click.command()

--- a/src/vivarium_ciff_sam/tools/make_artifacts.py
+++ b/src/vivarium_ciff_sam/tools/make_artifacts.py
@@ -12,7 +12,7 @@ import time
 import click
 
 from pathlib import Path
-from typing import Union
+from typing import Tuple, Union
 from loguru import logger
 
 import vivarium_cluster_tools as vct
@@ -31,29 +31,32 @@ def running_from_cluster() -> bool:
     return on_cluster
 
 
-def check_for_existing(output_dir: Path, location: str, append: bool):
+def check_for_existing(output_dir: Path, location: str, append: bool, replace_keys: Tuple):
     existing_artifacts = set([item.stem for item in output_dir.iterdir()
                               if item.is_file() and item.suffix == '.hdf'])
     locations = set([sanitize_location(loc) for loc in metadata.LOCATIONS])
     existing = locations.intersection(existing_artifacts)
 
-    if existing and not append:
+    if existing:
         if location != 'all':
             existing = [sanitize_location(location)]
-        click.confirm(f'Existing artifacts found for {existing}. Do you want to delete and rebuild?',
-                      abort=True)
-        for loc in existing:
-            path = output_dir / f'{loc}.hdf'
-            logger.info(f'Deleting artifact at {str(path)}.')
-            path.unlink()
+        if not append:
+            click.confirm(f'Existing artifacts found for {existing}. Do you want to delete and rebuild?', abort=True)
+            for loc in existing:
+                path = output_dir / f'{loc}.hdf'
+                logger.info(f'Deleting artifact at {str(path)}.')
+                path.unlink()
+        elif replace_keys:
+            click.confirm(f'Existing artifacts found for {existing}. If the listed keys {replace_keys} exist, they will'
+                          f' be deleted and regenerated. Do you want to delete and regenerate them?', abort=True)
 
 
-def build_single(location: str, output_dir: str, append: bool):
+def build_single(location: str, output_dir: str, replace_keys: Tuple):
     path = Path(output_dir) / f'{sanitize_location(location)}.hdf'
-    build_single_location_artifact(path, location)
+    build_single_location_artifact(path, location, replace_keys)
 
 
-def build_artifacts(location: str, output_dir: str, append: bool, verbose: int):
+def build_artifacts(location: str, output_dir: str, append: bool, replace_keys: Tuple, verbose: int):
     """Main application function for building artifacts.
     Parameters
     ----------
@@ -68,16 +71,19 @@ def build_artifacts(location: str, output_dir: str, append: bool, verbose: int):
     append
         Whether we should append to existing artifacts at the given output
         directory.  Has no effect if artifacts are not found.
+    replace_keys
+        A list of keys to replace in the artifact. Is ignored if append is
+        False or if there is no existing artifact at the output location
     verbose
         How noisy the logger should be.
     """
     output_dir = Path(output_dir)
     vct.mkdir(output_dir, parents=True, exists_ok=True)
 
-    check_for_existing(output_dir, location, append)
+    check_for_existing(output_dir, location, append, replace_keys)
 
     if location in metadata.LOCATIONS:
-        build_single(location, output_dir, append)
+        build_single(location, output_dir, replace_keys)
     elif location == 'all':
         if running_from_cluster():
             # parallel build when on cluster
@@ -85,7 +91,7 @@ def build_artifacts(location: str, output_dir: str, append: bool, verbose: int):
         else:
             # serial build when not on cluster
             for loc in metadata.LOCATIONS:
-                build_single(loc, output_dir, append)
+                build_single(loc, output_dir, replace_keys)
     else:
         raise ValueError(f'Location must be one of {metadata.LOCATIONS} or the string "all". '
                          f'You specified {location}.')
@@ -147,7 +153,8 @@ def build_all_artifacts(output_dir: Path, verbose: int):
     logger.info('**Done**')
 
 
-def build_single_location_artifact(path: Union[str, Path], location: str, log_to_file: bool = False):
+def build_single_location_artifact(path: Union[str, Path], location: str, replace_keys: Tuple = (),
+                                   log_to_file: bool = False):
     """Builds an artifact for a single location.
     Parameters
     ----------
@@ -156,6 +163,8 @@ def build_single_location_artifact(path: Union[str, Path], location: str, log_to
     location
         The location to build the artifact for.  Must be one of the locations
         specified in the project globals.
+    replace_keys
+        A list of artifact keys to replace
     log_to_file
         Whether we should write the application logs to a file.
     Note
@@ -182,7 +191,7 @@ def build_single_location_artifact(path: Union[str, Path], location: str, log_to
         logger.info(f'Loading and writing {key_group.log_name} data')
         for key in key_group:
             logger.info(f'   - Loading and writing {key} data')
-            builder.load_and_write_data(artifact, key, location)
+            builder.load_and_write_data(artifact, key, location, key in replace_keys)
 
     logger.info(f'**Done building -- {location}**')
 


### PR DESCRIPTION
I was getting tired of manually deleting keys from the artifact when I need to overwrite data. This allows you to target specific keys to overwrite. Usage looks like this:

`make_artifacts -vval Ethiopia -r risk_factor.child_wasting.distribution -r alternative_risk_factor.child_wasting.distribution`