### PR TITLE
remove wasting relative risks in neonatal age groups

### DIFF
--- a/src/vivarium_ciff_sam/data/loader.py
+++ b/src/vivarium_ciff_sam/data/loader.py
@@ -278,6 +278,11 @@ def load_gbd_2020_rr(key: str, location: str) -> pd.DataFrame:
                                                                       1.0), 1.0))
 
     data = utilities.validate_and_reshape_child_wasting_data(data, entity, key, location)
+
+    # Remove neonatal wasting relative risks
+    neonatal_age_ends = data.index.get_level_values('age_end').unique()[:2]
+    data.loc[data.index.get_level_values('age_end').isin(neonatal_age_ends)] = 1.0
+
     return data
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11376379/125989665-f6e2c30d-702d-4bc9-ba3f-6b8c25da2691.png)

Per the above, setting all wasting RRs to 1.0 for the two neonatal age groups. PAFs are calculated using these RRs, so they will also be affected.