### PR TITLE
fix person time counting bugs and add in exit age

### DIFF
--- a/src/vivarium_ciff_sam/components/observers.py
+++ b/src/vivarium_ciff_sam/components/observers.py
@@ -4,7 +4,6 @@ from typing import Callable, Dict, Iterable, List, Tuple
 import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
-from vivarium.framework.population import SimulantData
 from vivarium_public_health.metrics import (MortalityObserver as MortalityObserver_,
                                             DisabilityObserver as DisabilityObserver_,
                                             DiseaseObserver as DiseaseObserver_)
@@ -34,13 +33,10 @@ class ResultsStratifier:
         """Perform this component's setup."""
         # The only thing you should request here are resources necessary for results stratification.
         self.pipelines = {}
-        columns_required = [
-            'age',
-            data_keys.WASTING.name,
-        ]
+        columns_required = ['tracked']
 
-        def get_wasting_state_function(wasting_state):
-            return lambda: self.population_values[data_keys.WASTING.name] == wasting_state
+        def get_wasting_state_function(wasting_state: str) -> Callable:
+            return lambda pop: pop[data_keys.WASTING.name] == wasting_state
 
         self.stratification_levels = {}
 
@@ -49,25 +45,14 @@ class ResultsStratifier:
                 wasting_state: get_wasting_state_function(wasting_state)
                 for wasting_state in models.WASTING.STATES
             }
+            columns_required.append(data_keys.WASTING.name)
 
         self.population_view = builder.population.get_view(columns_required)
-        self.pipeline_values = {pipeline: None for pipeline in self.pipelines}
-        self.population_values = None
-        self.stratification_groups = None
 
-        builder.population.initializes_simulants(self.on_initialize_simulants,
-                                                 requires_columns=columns_required,
-                                                 requires_values=list(self.pipelines.keys()))
+    def get_stratification_groups(self, index: pd.Index):
+        #  add required pipelines to pop
+        pop = pd.concat([self.population_view.get(index)] + [pipeline(index) for pipeline in self.pipelines])
 
-        builder.event.register_listener('time_step__cleanup', self.on_timestep_cleanup)
-
-    # noinspection PyAttributeOutsideInit
-    def on_initialize_simulants(self, pop_data: SimulantData):
-        self.pipeline_values = {name: pipeline(pop_data.index) for name, pipeline in self.pipelines.items()}
-        self.population_values = self.population_view.get(pop_data.index)
-        self.stratification_groups = self.get_stratification_groups(pop_data.index)
-
-    def get_stratification_groups(self, index):
         stratification_groups = pd.Series('', index=index)
         all_stratifications = self.get_all_stratifications()
         for stratification in all_stratifications:
@@ -75,15 +60,9 @@ class ResultsStratifier:
                                                   for metric in stratification])
             mask = pd.Series(True, index=index)
             for metric in stratification:
-                mask &= self.stratification_levels[metric['metric']][metric['category']]()
+                mask &= self.stratification_levels[metric['metric']][metric['category']](pop)
             stratification_groups.loc[mask] = stratification_group_name
         return stratification_groups
-
-    # noinspection PyAttributeOutsideInit
-    def on_timestep_cleanup(self, event: Event):
-        self.pipeline_values = {name: pipeline(event.index) for name, pipeline in self.pipelines.items()}
-        self.population_values = self.population_view.get(event.index)
-        self.stratification_groups = self.get_stratification_groups(event.index)
 
     def get_all_stratifications(self) -> List[Tuple[Dict[str, str], ...]]:
         """
@@ -119,7 +98,7 @@ class ResultsStratifier:
             corresponding to those labels.
 
         """
-        stratification_groups = self.stratification_groups.loc[pop.index]
+        stratification_groups = self.get_stratification_groups(pop.index)
         stratifications = self.get_all_stratifications()
         for stratification in stratifications:
             stratification_key = self.get_stratification_key(stratification)

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -49,6 +49,7 @@ configuration:
         population_size: 10000
         age_start: 0
         age_end: 5
+        exit_age: 5
 
     wasting_equations:
         include_mortality: False


### PR DESCRIPTION
Adding an exit age fixes our low birth rate, so that should solve the declining population. 

Moving the setting of `self.stratification_groups` to `time_step__cleanup` means that it wont conflict with observers, since they don't do anything in that phase. 

Person time is tracked on `time_step__prepare`, so this means that people who weren't born this timestep will have had their stratification group (right now that just means wasting state) correctly updated in the previous timestep's cleanup phase. Simulants born this timestep are technically born at the end of the timestep, so they don't accrue any person time. Also they haven't been born by `time_step__prepare` anyway, since they are born during `time_step`. 

Event counts like disease transitions are tracked on `collect_metrics` which happens after `time_step__cleanup`. This means stratification groups will be updated between these events "occurring" and being counted. That is a change of behavior, but this only has an impact where the even occurs in the same timestep in which wasting state changes. If I'm understanding vivarium correctly however, this means that while the internal state change occurs during `time_step`, in the simulation universe the event occurs at the same instant that the wasting state changes (at the end of the timestep in question). I'm not sure there's a meaningful way of saying which wasting state you are in, when that changes at the same time that the event occurs. In any case, this shouldn't be a common occurrence relative to the magnitude of the counts. 

The `DisabilityObserver` counts disability during `time_step__prepare`, so the same point holds as in the person time paragraph.

The `MortalityObserver` counts at the very end of the simulation, so this has no impact.