### PR TITLE
update stratifier to cache state and stratify by stunting

### DIFF
--- a/src/vivarium_ciff_sam/components/observers.py
+++ b/src/vivarium_ciff_sam/components/observers.py
@@ -24,9 +24,10 @@ class ResultsStratifier:
 
     """
 
-    def __init__(self, observer_name: str, by_wasting: bool = True):
+    def __init__(self, observer_name: str, by_wasting: bool = True, by_stunting: bool = False):
         self.name = f'{observer_name}_results_stratifier'
         self.by_wasting = by_wasting
+        self.by_stunting = by_stunting
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
@@ -35,26 +36,45 @@ class ResultsStratifier:
         self.pipelines = {}
         columns_required = ['tracked']
 
-        def get_wasting_state_function(wasting_state: str) -> Callable:
-            return lambda pop: pop[data_keys.WASTING.name] == wasting_state
+        def get_state_function(column_name: str, state_name: str) -> Callable:
+            return lambda pop: pop[column_name] == state_name
 
         self.stratification_levels = {}
 
         if self.by_wasting:
             self.stratification_levels['wasting_state'] = {
-                wasting_state: get_wasting_state_function(wasting_state)
+                wasting_state: get_state_function(data_keys.WASTING.name, wasting_state)
                 for wasting_state in models.WASTING.STATES
             }
             columns_required.append(data_keys.WASTING.name)
 
+        if self.by_stunting:
+            self.stratification_levels['stunting_state'] = {
+                f'cat{i}': get_state_function(data_keys.STUNTING.name, f'cat{i}')
+                for i in range(4, 0, -1)
+            }
+            self.pipelines[data_keys.STUNTING.name] = builder.value.get_value('child_stunting.exposure')
+
         self.population_view = builder.population.get_view(columns_required)
+        self.stratification_groups: pd.Series = None
+
+        # Ensure that the stratifier updates before its observer
+        builder.event.register_listener('time_step__prepare', self.on_timestep_prepare, priority=0)
+
+    # noinspection PyAttributeOutsideInit
+    def on_timestep_prepare(self, event: Event):
+        # cache stratification groups at the beginning of the time-step for use later when stratifying
+        self.stratification_groups = self.get_stratification_groups(event.index)
 
     def get_stratification_groups(self, index: pd.Index):
-        #  add required pipelines to pop
-        pop = pd.concat([self.population_view.get(index)] + [pipeline(index) for pipeline in self.pipelines])
+        #  get values required for stratification from population view and pipelines
+        pop_list = [self.population_view.get(index)] + [pd.Series(pipeline(index), name=name)
+                                                        for name, pipeline in self.pipelines.items()]
+        pop = pd.concat(pop_list, axis=1)
 
         stratification_groups = pd.Series('', index=index)
         all_stratifications = self.get_all_stratifications()
+        # todo do this without requiring the doubly nested loop by concatting strings
         for stratification in all_stratifications:
             stratification_group_name = '_'.join([f'{metric["metric"]}_{metric["category"]}'
                                                   for metric in stratification])
@@ -98,7 +118,10 @@ class ResultsStratifier:
             corresponding to those labels.
 
         """
-        stratification_groups = self.get_stratification_groups(pop.index)
+        index = pop.index.intersection(self.stratification_groups.index)
+        pop = pop.loc[index]
+        stratification_groups = self.stratification_groups.loc[index]
+
         stratifications = self.get_all_stratifications()
         for stratification in stratifications:
             stratification_key = self.get_stratification_key(stratification)
@@ -199,9 +222,9 @@ class DisabilityObserver(DisabilityObserver_):
 
 class DiseaseObserver(DiseaseObserver_):
 
-    def __init__(self, disease: str, stratify_by_wasting: str = 'True'):
+    def __init__(self, disease: str, stratify_by_wasting: str = 'True', stratify_by_stunting: str = 'False'):
         super().__init__(disease)
-        self.stratifier = ResultsStratifier(self.name, stratify_by_wasting == 'True')
+        self.stratifier = ResultsStratifier(self.name, stratify_by_wasting == 'True', stratify_by_stunting == 'True')
 
     @property
     def sub_components(self) -> List[ResultsStratifier]:

--- a/src/vivarium_ciff_sam/components/observers.py
+++ b/src/vivarium_ciff_sam/components/observers.py
@@ -157,9 +157,9 @@ class ResultsStratifier:
 
 class MortalityObserver(MortalityObserver_):
 
-    def __init__(self):
+    def __init__(self, stratify_by_wasting: str = 'True', stratify_by_stunting: str = 'False'):
         super().__init__()
-        self.stratifier = ResultsStratifier(self.name)
+        self.stratifier = ResultsStratifier(self.name, stratify_by_wasting == 'True', stratify_by_stunting == 'True')
 
     @property
     def sub_components(self) -> List[ResultsStratifier]:
@@ -195,9 +195,9 @@ class MortalityObserver(MortalityObserver_):
 
 class DisabilityObserver(DisabilityObserver_):
 
-    def __init__(self):
+    def __init__(self, stratify_by_wasting: str = 'True', stratify_by_stunting: str = 'False'):
         super().__init__()
-        self.stratifier = ResultsStratifier(self.name)
+        self.stratifier = ResultsStratifier(self.name, stratify_by_wasting == 'True', stratify_by_stunting == 'True')
 
     @property
     def sub_components(self) -> List[ResultsStratifier]:

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -22,9 +22,9 @@ components:
             - ChildWasting()
             - DisabilityObserver()
             - MortalityObserver()
-            - DiseaseObserver('diarrheal_diseases')
-            - DiseaseObserver('measles')
-            - DiseaseObserver('lower_respiratory_infections')
+            - DiseaseObserver('diarrheal_diseases', 'False', 'True')
+            - DiseaseObserver('measles', 'False', 'True')
+            - DiseaseObserver('lower_respiratory_infections', 'False', 'True')
             - DiseaseObserver('child_wasting', 'False')
 
 configuration:

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -20,8 +20,8 @@ components:
     vivarium_ciff_sam:
         components:
             - ChildWasting()
-            - DisabilityObserver()
-            - MortalityObserver()
+            - DisabilityObserver('False', 'True')
+            - MortalityObserver('False', 'True')
             - DiseaseObserver('diarrheal_diseases', 'False', 'True')
             - DiseaseObserver('measles', 'False', 'True')
             - DiseaseObserver('lower_respiratory_infections', 'False', 'True')


### PR DESCRIPTION
Updated the Stratifier so that it caches stratification groups on timestep prepare and ensure that this runs before any observers act. 

Add the ability to stratify by stunting state, which requires being able to use pipelines in stratification.

Update the configuration to temporarily remove wasting stratification from observers and add stunting stratification.