### PR TITLE
Feature/scenario treatment

### DIFF
--- a/src/vivarium_ciff_sam/components/__init__.py
+++ b/src/vivarium_ciff_sam/components/__init__.py
@@ -1,4 +1,4 @@
-from vivarium_ciff_sam.components.intervention import Intervention
+from vivarium_ciff_sam.components.intervention import SQLNSIntervention, WastingTreatmentIntervention
 from vivarium_ciff_sam.components.observers import (CategoricalRiskObserver, DisabilityObserver, DiseaseObserver,
                                                     MortalityObserver)
 from vivarium_ciff_sam.components.treatment import SQLNSTreatment

--- a/src/vivarium_ciff_sam/components/intervention.py
+++ b/src/vivarium_ciff_sam/components/intervention.py
@@ -5,21 +5,15 @@ from vivarium.framework.engine import Builder
 from vivarium_ciff_sam.constants import data_keys, data_values, scenarios
 
 
-class Intervention:
-
-    configuration_defaults = {
-        'intervention': {
-            'scenario': scenarios.SCENARIOS.BASELINE
-        }
-    }
+class SQLNSIntervention:
 
     def __init__(self):
-        self.name = 'intervention'
+        self.name = 'sqlns_intervention'
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: 'Builder'):
         """Perform this component's setup."""
-        self.scenario = builder.configuration.intervention.scenario
+        self.scenario = scenarios.SCENARIOS[builder.configuration.intervention.scenario]
         self.clock = builder.time.clock()
 
         required_columns = [
@@ -28,7 +22,7 @@ class Intervention:
 
         builder.value.register_value_modifier(
             data_keys.SQ_LNS.COVERAGE,
-            modifier=self.sq_lns_coverage_intervention_effect,
+            modifier=self.coverage_effect,
             requires_columns=['age'],
             requires_values=[data_keys.SQ_LNS.PROPENSITY]
         )
@@ -37,14 +31,43 @@ class Intervention:
         self.population_view = builder.population.get_view(required_columns)
 
     # define a function to do the modification
-    def sq_lns_coverage_intervention_effect(self, idx: pd.Index, target: pd.Series) -> pd.Series:
+    def coverage_effect(self, idx: pd.Index, target: pd.Series) -> pd.Series:
         effect = False
 
         # if this is the alternative scenario and the scale up has already started calculate effect
-        if self.scenario == scenarios.SCENARIOS.BOTH and data_values.SCALE_UP_START_DT <= self.clock():
+        if self.scenario.has_sqlns and data_values.SCALE_UP_START_DT <= self.clock():
             age = self.population_view.get(idx)['age']
             propensity = self.sq_lns_coverage_propensity(idx)
             effect = ((data_values.SQ_LNS.COVERAGE_START_AGE <= age)
                       & (propensity < data_values.SQ_LNS.COVERAGE_RAMP_UP))
 
         return target | effect
+
+
+class WastingTreatmentIntervention:
+
+    def __init__(self):
+        self.name = 'wasting_treatment_intervention'
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: 'Builder'):
+        """Perform this component's setup."""
+        self.scenario = scenarios.SCENARIOS[builder.configuration.intervention.scenario]
+        self.clock = builder.time.clock()
+
+        builder.value.register_value_modifier(
+            f'risk_factor.{data_keys.WASTING_TREATMENT.name}.exposure_parameters',
+            modifier=self.coverage_effect,
+        )
+
+    # define a function to do the modification
+    def coverage_effect(self, idx: pd.Index, target: pd.Series) -> pd.Series:
+        effect = False
+
+        # if this is the alternative scenario and the scale up has already started update coverage
+        if self.scenario.has_alternative_treatment and data_values.SCALE_UP_START_DT <= self.clock():
+            target['cat1'] = 0.1
+            target['cat2'] = 0.0
+            target['cat3'] = 0.9
+
+        return target

--- a/src/vivarium_ciff_sam/components/observers.py
+++ b/src/vivarium_ciff_sam/components/observers.py
@@ -56,15 +56,15 @@ class ResultsStratifier:
                 f'cat{i}': get_state_function(data_keys.STUNTING.name, f'cat{i}')
                 for i in range(4, 0, -1)
             }
-            self.pipelines[data_keys.STUNTING.name] = builder.value.get_value('child_stunting.exposure')
+            self.pipelines[data_keys.STUNTING.name] = builder.value.get_value(f'{data_keys.STUNTING.name}.exposure')
 
         if self.by_wasting_treatment:
-            wasting_treatment_key = data_keys.WASTING_NON_TREATMENT.name
+            wasting_treatment_key = data_keys.WASTING_TREATMENT.name
             self.stratification_levels['wasting_treatment'] = {
                 coverage: get_state_function(wasting_treatment_key, category)
                 for category, coverage in (('cat2', 'covered'), ('cat1', 'uncovered'))
             }
-            self.pipelines[wasting_treatment_key] = builder.value.get_value('wasting_non_treatment.exposure')
+            self.pipelines[wasting_treatment_key] = builder.value.get_value(f'{wasting_treatment_key}.exposure')
 
         if self.by_sqlns:
             self.stratification_levels['sq_lns'] = {

--- a/src/vivarium_ciff_sam/components/wasting.py
+++ b/src/vivarium_ciff_sam/components/wasting.py
@@ -222,9 +222,9 @@ def load_mam_exposure(cause: str, builder: Builder) -> pd.DataFrame:
 # noinspection PyUnusedLocal, DuplicatedCode
 def load_mam_incidence_rate(builder: Builder, *args) -> pd.DataFrame:
     draw = builder.configuration.input_data.input_draw_number
-    tx_coverage = get_random_variable(draw, *data_values.WASTING.TX_COVERAGE)
-    mam_tx_efficacy = get_random_variable(draw, *data_values.WASTING.MAM_TX_EFFICACY)
-    sam_tx_efficacy = get_random_variable(draw, *data_values.WASTING.SAM_TX_EFFICACY)
+    tx_coverage = get_random_variable(draw, *data_values.WASTING.BASELINE_TX_COVERAGE)
+    mam_tx_efficacy = get_random_variable(draw, *data_values.WASTING.BASELINE_MAM_TX_EFFICACY)
+    sam_tx_efficacy = get_random_variable(draw, *data_values.WASTING.BASELINE_SAM_TX_EFFICACY)
 
     exposures = load_child_wasting_exposures(builder)
     adjustment = load_acmr_adjustment(builder)
@@ -262,8 +262,8 @@ def get_daily_mam_incidence_probability(exposures: pd.DataFrame, adjustment: pd.
 def load_mam_remission_rate(builder: Builder, *args) -> float:
     draw = builder.configuration.input_data.input_draw_number
     index = builder.data.load(data_keys.POPULATION.DEMOGRAPHY).set_index(metadata.ARTIFACT_INDEX_COLUMNS).index
-    tx_coverage = get_random_variable(draw, *data_values.WASTING.TX_COVERAGE)
-    mam_tx_efficacy = get_random_variable(draw, *data_values.WASTING.MAM_TX_EFFICACY)
+    tx_coverage = get_random_variable(draw, *data_values.WASTING.BASELINE_TX_COVERAGE)
+    mam_tx_efficacy = get_random_variable(draw, *data_values.WASTING.BASELINE_MAM_TX_EFFICACY)
 
     daily_probability = get_daily_mam_remission_probability(index, tx_coverage, mam_tx_efficacy)
     incidence_rate = _convert_daily_probability_to_annual_rate(daily_probability)
@@ -299,8 +299,8 @@ def load_sam_exposure(cause: str, builder: Builder) -> pd.DataFrame:
 # noinspection PyUnusedLocal, DuplicatedCode
 def load_sam_incidence_rate(builder: Builder, *args) -> pd.DataFrame:
     draw = builder.configuration.input_data.input_draw_number
-    tx_coverage = get_random_variable(draw, *data_values.WASTING.TX_COVERAGE)
-    sam_tx_efficacy = get_random_variable(draw, *data_values.WASTING.SAM_TX_EFFICACY)
+    tx_coverage = get_random_variable(draw, *data_values.WASTING.BASELINE_TX_COVERAGE)
+    sam_tx_efficacy = get_random_variable(draw, *data_values.WASTING.BASELINE_SAM_TX_EFFICACY)
     sam_k = get_random_variable(draw, *data_values.WASTING.SAM_K)
 
     exposures = load_child_wasting_exposures(builder)
@@ -339,8 +339,8 @@ def get_daily_sam_incidence_probability(exposures: pd.DataFrame, adjustment: pd.
 # noinspection PyUnusedLocal
 def load_sam_untreated_remission_rate(builder: Builder, *args) -> pd.Series:
     draw = builder.configuration.input_data.input_draw_number
-    tx_coverage = get_random_variable(draw, *data_values.WASTING.TX_COVERAGE)
-    sam_tx_efficacy = get_random_variable(draw, *data_values.WASTING.SAM_TX_EFFICACY)
+    tx_coverage = get_random_variable(draw, *data_values.WASTING.BASELINE_TX_COVERAGE)
+    sam_tx_efficacy = get_random_variable(draw, *data_values.WASTING.BASELINE_SAM_TX_EFFICACY)
     sam_k = get_random_variable(draw, *data_values.WASTING.SAM_K)
     mortality_probs = load_daily_mortality_probabilities(builder)
 
@@ -368,9 +368,9 @@ def get_daily_sam_untreated_remission_probability(mortality_probs: pd.DataFrame,
 def load_sam_treated_remission_rate(builder: Builder, *args) -> float:
     index = builder.data.load(data_keys.POPULATION.DEMOGRAPHY).set_index(metadata.ARTIFACT_INDEX_COLUMNS).index
     tx_coverage = get_random_variable(builder.configuration.input_data.input_draw_number,
-                                      *data_values.WASTING.TX_COVERAGE)
+                                      *data_values.WASTING.BASELINE_TX_COVERAGE)
     sam_tx_efficacy = get_random_variable(builder.configuration.input_data.input_draw_number,
-                                          *data_values.WASTING.SAM_TX_EFFICACY)
+                                          *data_values.WASTING.BASELINE_SAM_TX_EFFICACY)
 
     daily_probability = get_daily_sam_treated_remission_probability(index, tx_coverage, sam_tx_efficacy)
     remission_rate = _convert_daily_probability_to_annual_rate(daily_probability)

--- a/src/vivarium_ciff_sam/constants/data_keys.py
+++ b/src/vivarium_ciff_sam/constants/data_keys.py
@@ -210,24 +210,28 @@ class __SQLNS(NamedTuple):
 SQ_LNS = __SQLNS()
 
 
-class __WastingNonTreatment(NamedTuple):
+class __WastingTreatment(NamedTuple):
 
     # Keys that will be loaded into the artifact. must have a colon type declaration
-    EXPOSURE: TargetString = 'risk_factor.wasting_non_treatment.exposure'
-    DISTRIBUTION: TargetString = 'risk_factor.wasting_non_treatment.distribution'
-    RELATIVE_RISK: TargetString = 'risk_factor.wasting_non_treatment.relative_risk'
-    PAF: TargetString = 'risk_factor.wasting_non_treatment.population_attributable_fraction'
+    EXPOSURE: TargetString = 'risk_factor.wasting_treatment.exposure'
+    DISTRIBUTION: TargetString = 'risk_factor.wasting_treatment.distribution'
+    CATEGORIES: TargetString = 'risk_factor.wasting_treatment.categories'
+    RELATIVE_RISK: TargetString = 'risk_factor.wasting_treatment.relative_risk'
+    PAF: TargetString = 'risk_factor.wasting_treatment.population_attributable_fraction'
+
+    # Useful keys not for the artifact - distinguished by not using the colon type declaration
+    TMREL_CATEGORY = 'cat2'
 
     @property
     def name(self):
-        return 'wasting_non_treatment'
+        return 'wasting_treatment'
 
     @property
     def log_name(self):
-        return 'wasting non-treatment'
+        return 'wasting treatment'
 
 
-WASTING_NON_TREATMENT = __WastingNonTreatment()
+WASTING_TREATMENT = __WastingTreatment()
 
 
 MAKE_ARTIFACT_KEY_GROUPS = [
@@ -239,5 +243,5 @@ MAKE_ARTIFACT_KEY_GROUPS = [
     WASTING,
     STUNTING,
     SQ_LNS,
-    WASTING_NON_TREATMENT,
+    WASTING_TREATMENT,
 ]

--- a/src/vivarium_ciff_sam/constants/data_values.py
+++ b/src/vivarium_ciff_sam/constants/data_values.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from typing import NamedTuple, Tuple
 
-from scipy import stats
-
-from vivarium_ciff_sam.utilities import get_lognorm_from_quantiles
+from vivarium_ciff_sam.utilities import get_norm_from_quantiles, get_lognorm_from_quantiles
 
 #######################
 # Universal Constants #
@@ -38,11 +36,14 @@ class __Wasting(NamedTuple):
 
     # Wasting treatment coverage
     COVERAGE_START_AGE: float = 28 / YEAR_DURATION  # ~0.0767
-    TX_COVERAGE: Tuple = ('sam_tx_coverage', stats.norm(loc=0.488, scale=0.0587))      # (0.604 - 0.374) / (2 * 1.96)
+    BASELINE_TX_COVERAGE: Tuple = ('sam_tx_coverage', get_norm_from_quantiles(mean=0.488, lower=0.374, upper=0.604))
+    ALTERNATIVE_TX_COVERAGE: float = 0.9
 
     # Wasting treatment efficacy
-    SAM_TX_EFFICACY: Tuple = ('sam_tx_efficacy', stats.norm(loc=0.700, scale=0.0306))  # (0.760 - 0.640) / (2 * 1.96)
-    MAM_TX_EFFICACY: Tuple = ('mam_tx_efficacy', stats.norm(loc=0.731, scale=0.0745))  # (0.877 - 0.585) / (2 * 1.96)
+    BASELINE_SAM_TX_EFFICACY: Tuple = ('sam_tx_efficacy', get_norm_from_quantiles(mean=0.700, lower=0.64, upper=0.76))
+    BASELINE_MAM_TX_EFFICACY: Tuple = ('mam_tx_efficacy', get_norm_from_quantiles(mean=0.731, lower=0.585, upper=0.877))
+    SAM_TX_ALTERNATIVE_EFFICACY: float = 0.75
+    MAM_TX_ALTERNATIVE_EFFICACY: float = 0.75
 
     # Incidence correction factor (total exit rate)
     SAM_K: float = ('sam_incidence_correction', get_lognorm_from_quantiles(median=6.7, lower=5.3, upper=8.4))

--- a/src/vivarium_ciff_sam/constants/scenarios.py
+++ b/src/vivarium_ciff_sam/constants/scenarios.py
@@ -1,14 +1,16 @@
-from typing import NamedTuple
-
-
 #############
 # Scenarios #
 #############
 
-class __Scenarios(NamedTuple):
-    BASELINE: str = 'baseline'
-    TREATMENT: str = 'treatment_only'
-    BOTH: str = 'treatment_and_prevention'
+class Scenario:
+
+    def __init__(self, has_alternative_treatment: bool, has_sqlns: bool):
+        self.has_alternative_treatment = has_alternative_treatment
+        self.has_sqlns = has_sqlns
 
 
-SCENARIOS = __Scenarios()
+SCENARIOS = {
+    'baseline': Scenario(False, False),
+    'wasting_treatment': Scenario(True, False),
+    'sqlns': Scenario(True, True),
+}

--- a/src/vivarium_ciff_sam/data/loader.py
+++ b/src/vivarium_ciff_sam/data/loader.py
@@ -94,10 +94,11 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.STUNTING.RELATIVE_RISK: load_gbd_2020_rr,
         data_keys.STUNTING.PAF: load_paf,
 
-        data_keys.WASTING_NON_TREATMENT.DISTRIBUTION: load_wasting_non_treatment_distribution,
-        data_keys.WASTING_NON_TREATMENT.EXPOSURE: load_wasting_non_treatment_exposure,
-        data_keys.WASTING_NON_TREATMENT.RELATIVE_RISK: load_wasting_non_treatment_rr,
-        data_keys.WASTING_NON_TREATMENT.PAF: load_paf,
+        data_keys.WASTING_TREATMENT.DISTRIBUTION: load_wasting_treatment_distribution,
+        data_keys.WASTING_TREATMENT.CATEGORIES: load_wasting_treatment_categories,
+        data_keys.WASTING_TREATMENT.EXPOSURE: load_wasting_treatment_exposure,
+        data_keys.WASTING_TREATMENT.RELATIVE_RISK: load_wasting_treatment_rr,
+        data_keys.WASTING_TREATMENT.PAF: load_paf,
     }
     return mapping[lookup_key](lookup_key, location)
 
@@ -276,11 +277,11 @@ def load_gbd_2020_rr(key: str, location: str) -> pd.DataFrame:
 
 
 def load_paf(key: str, location: str) -> pd.DataFrame:
-    if key in [data_keys.WASTING.PAF, data_keys.STUNTING.PAF, data_keys.WASTING_NON_TREATMENT.PAF]:
+    if key in [data_keys.WASTING.PAF, data_keys.STUNTING.PAF, data_keys.WASTING_TREATMENT.PAF]:
         risk = {
             data_keys.WASTING.PAF: data_keys.WASTING,
             data_keys.STUNTING.PAF: data_keys.STUNTING,
-            data_keys.WASTING_NON_TREATMENT.PAF: data_keys.WASTING_NON_TREATMENT
+            data_keys.WASTING_TREATMENT.PAF: data_keys.WASTING_TREATMENT
         }[key]
 
         exp = get_data(risk.EXPOSURE, location)
@@ -329,41 +330,85 @@ def load_pem_disability_weight(key: str, location: str) -> pd.DataFrame:
 
 
 # noinspection PyUnusedLocal
-def load_wasting_non_treatment_distribution(key: str, location: str) -> str:
-    if key == data_keys.WASTING_NON_TREATMENT.DISTRIBUTION:
-        return 'dichotomous'
+def load_wasting_treatment_distribution(key: str, location: str) -> str:
+    if key == data_keys.WASTING_TREATMENT.DISTRIBUTION:
+        return 'ordered_polytomous'
     else:
         raise ValueError(f'Unrecognized key {key}')
 
 
 # noinspection PyUnusedLocal
-def load_wasting_non_treatment_exposure(key: str, location: str) -> pd.DataFrame:
-    if key == data_keys.WASTING_NON_TREATMENT.EXPOSURE:
+def load_wasting_treatment_categories(key: str, location: str) -> str:
+    if key == data_keys.WASTING_TREATMENT.CATEGORIES:
+        return {
+            'cat1': 'Untreated',
+            'cat2': 'Baseline treatment',
+            'cat3': 'Alternative scenario treatment',
+        }
+    else:
+        raise ValueError(f'Unrecognized key {key}')
+
+
+# noinspection PyUnusedLocal
+def load_wasting_treatment_exposure(key: str, location: str) -> pd.DataFrame:
+    if key == data_keys.WASTING_TREATMENT.EXPOSURE:
         treatment_coverage = get_random_variable_draws(pd.Index([f'draw_{i}' for i in range(0, 1000)]),
-                                                       *data_values.WASTING.TX_COVERAGE)
+                                                       *data_values.WASTING.BASELINE_TX_COVERAGE)
 
         idx = get_data(data_keys.POPULATION.DEMOGRAPHY, location).index
-        cat2 = pd.DataFrame({f'draw_{i}': 1 for i in range(0, 1000)}, index=idx) * treatment_coverage
+        cat3 = pd.DataFrame({f'draw_{i}': 0.0 for i in range(0, 1000)}, index=idx)
+        cat2 = pd.DataFrame({f'draw_{i}': 1.0 for i in range(0, 1000)}, index=idx) * treatment_coverage
         cat1 = 1 - cat2
 
         cat1['parameter'] = 'cat1'
         cat2['parameter'] = 'cat2'
+        cat3['parameter'] = 'cat3'
 
-        exposure = pd.concat([cat1, cat2]).set_index('parameter', append=True).sort_index()
+        exposure = pd.concat([cat1, cat2, cat3]).set_index('parameter', append=True).sort_index()
         return exposure
     else:
         raise ValueError(f'Unrecognized key {key}')
 
 
-def load_wasting_non_treatment_rr(key: str, location: str) -> pd.DataFrame:
-    if key == data_keys.WASTING_NON_TREATMENT.RELATIVE_RISK:
-        sam_treatment_efficacy = get_random_variable_draws(pd.Index([f'draw_{i}' for i in range(0, 1000)]),
-                                                           *data_values.WASTING.SAM_TX_EFFICACY)
-        mam_treatment_efficacy = get_random_variable_draws(pd.Index([f'draw_{i}' for i in range(0, 1000)]),
-                                                           *data_values.WASTING.MAM_TX_EFFICACY)
+def load_wasting_treatment_rr(key: str, location: str) -> pd.DataFrame:
+    # tmrel is defined as baseline treatment (cat_2)
+    if key == data_keys.WASTING_TREATMENT.RELATIVE_RISK:
+        idx_as_frame = (
+            get_data(data_keys.POPULATION.DEMOGRAPHY, location).reset_index()
+            .merge(pd.DataFrame({'parameter': [f'cat{i}' for i in range(1, 4)]}), how='cross')
+        )
+        idx = idx_as_frame.set_index(list(idx_as_frame.columns)).index
 
-        idx = get_data(data_keys.POPULATION.DEMOGRAPHY, location).index
+        raw_efficacy = {
+            'baseline': {
+                'sam': get_random_variable_draws(pd.Index([f'draw_{i}' for i in range(0, 1000)]),
+                                                 *data_values.WASTING.BASELINE_SAM_TX_EFFICACY),
+                'mam': get_random_variable_draws(pd.Index([f'draw_{i}' for i in range(0, 1000)]),
+                                                 *data_values.WASTING.BASELINE_MAM_TX_EFFICACY)
+            }, 'alternative': {
+                'sam': data_values.WASTING.SAM_TX_ALTERNATIVE_EFFICACY,
+                'mam': data_values.WASTING.MAM_TX_ALTERNATIVE_EFFICACY
+            }
+        }
 
+        def get_treatment_efficacy(treatment_type: str) -> pd.DataFrame:
+            efficacy = pd.DataFrame({f'draw_{i}': 1.0 for i in range(0, 1000)}, index=idx)
+            efficacy[idx.get_level_values('parameter') == 'cat1'] *= 0.0
+            efficacy[idx.get_level_values('parameter') == 'cat2'] *= raw_efficacy['baseline'][treatment_type]
+            efficacy[idx.get_level_values('parameter') == 'cat3'] *= raw_efficacy['alternative'][treatment_type]
+            return efficacy
+
+        sam_tx_efficacy = get_treatment_efficacy('sam')
+        mam_tx_efficacy = get_treatment_efficacy('mam')
+
+        def get_tmrel_efficacy(efficacy: pd.DataFrame) -> pd.DataFrame:
+            return efficacy[efficacy.index.get_level_values('parameter')
+                            == data_keys.WASTING_TREATMENT.TMREL_CATEGORY].droplevel('parameter')
+
+        sam_tx_efficacy_tmrel = get_tmrel_efficacy(sam_tx_efficacy)
+        mam_tx_efficacy_tmrel = get_tmrel_efficacy(mam_tx_efficacy)
+
+        mam_ux_duration = data_values.WASTING.MAM_UX_RECOVERY_TIME
         mam_tx_duration = pd.Series(index=idx)
         mam_tx_duration[idx.get_level_values('age_start') < 0.5] = data_values.WASTING.MAM_TX_RECOVERY_TIME_UNDER_6MO
         mam_tx_duration[0.5 <= idx.get_level_values('age_start')] = data_values.WASTING.MAM_TX_RECOVERY_TIME_OVER_6MO
@@ -372,27 +417,32 @@ def load_wasting_non_treatment_rr(key: str, location: str) -> pd.DataFrame:
             .multiply(mam_tx_duration, axis='index')
         )
 
-        rr_sam_treated_remission = pd.DataFrame({f'draw_{i}': 0 for i in range(0, 1000)}, index=idx)
+        # rr_t1 = t1 / t1_tmrel
+        #       = (sam_tx_efficacy / sam_tx_duration) / (sam_tx_efficacy_tmrel / sam_tx_duration)
+        #       = sam_tx_efficacy / sam_tx_efficacy_tmrel
+        rr_sam_treated_remission = sam_tx_efficacy / sam_tx_efficacy_tmrel
         rr_sam_treated_remission['affected_entity'] = 'severe_acute_malnutrition_to_mild_child_wasting'
-        rr_sam_untreated_remission = (pd.DataFrame({f'draw_{i}': 1 for i in range(0, 1000)}, index=idx)
-                                      / (1 - sam_treatment_efficacy))
+
+        # rr_r2 = r2 / r2_tmrel
+        #       = (1 - sam_tx_efficacy) * (r2_ux) / (1 - sam_tx_efficacy_tmrel) * (r2_ux)
+        #       = (1 - sam_tx_efficacy) / (1 - sam_tx_efficacy_tmrel)
+        rr_sam_untreated_remission = (1 - sam_tx_efficacy) / (1 - sam_tx_efficacy_tmrel)
         rr_sam_untreated_remission['affected_entity'] = 'severe_acute_malnutrition_to_moderate_acute_malnutrition'
-        rr_mam_remission = (mam_tx_duration
-                            / (mam_tx_duration * (1 - mam_treatment_efficacy)
-                               + data_values.WASTING.MAM_UX_RECOVERY_TIME * mam_treatment_efficacy))
+
+        # rr_r3 = r3 / r3_tmrel
+        #       = (mam_tx_efficacy / mam_tx_duration) + (1 - mam_tx_efficacy / mam_ux_duration)
+        #           / (mam_tx_efficacy_tmrel / mam_tx_duration) + (1 - mam_tx_efficacy_tmrel / mam_ux_duration)
+        #       = (mam_tx_efficacy * mam_ux_duration + (1 - mam_tx_efficacy) * mam_tx_duration)
+        #           / (mam_tx_efficacy_tmrel * mam_ux_duration + (1 - mam_tx_efficacy_tmrel) * mam_tx_duration)
+        rr_mam_remission = ((mam_tx_efficacy * mam_ux_duration + (1 - mam_tx_efficacy) * mam_tx_duration)
+                            / (mam_tx_efficacy_tmrel * mam_ux_duration + (1 - mam_tx_efficacy_tmrel) * mam_tx_duration))
         rr_mam_remission['affected_entity'] = 'moderate_acute_malnutrition_to_mild_child_wasting'
 
-        cat1 = pd.concat(
+        rr = pd.concat(
             [rr_sam_treated_remission, rr_sam_untreated_remission, rr_mam_remission]
         )
-        cat1['affected_measure'] = 'transition_rate'
-        cat1 = cat1.set_index(['affected_entity', 'affected_measure'], append=True)
-        cat2 = pd.DataFrame(1, columns=cat1.columns, index=cat1.index)
-
-        cat1['parameter'] = 'cat1'
-        cat2['parameter'] = 'cat2'
-
-        rr = pd.concat([cat1, cat2]).set_index('parameter', append=True).sort_index()
+        rr['affected_measure'] = 'transition_rate'
+        rr = rr.set_index(['affected_entity', 'affected_measure'], append=True).sort_index()
         return rr
     else:
         raise ValueError(f'Unrecognized key {key}')

--- a/src/vivarium_ciff_sam/data/loader.py
+++ b/src/vivarium_ciff_sam/data/loader.py
@@ -442,7 +442,9 @@ def load_wasting_treatment_rr(key: str, location: str) -> pd.DataFrame:
             [rr_sam_treated_remission, rr_sam_untreated_remission, rr_mam_remission]
         )
         rr['affected_measure'] = 'transition_rate'
-        rr = rr.set_index(['affected_entity', 'affected_measure'], append=True).sort_index()
+        rr = rr.set_index(['affected_entity', 'affected_measure'], append=True)
+        rr.index = rr.index.reorder_levels([col for col in rr.index.names if col != 'parameter'] + ['parameter'])
+        rr.sort_index()
         return rr
     else:
         raise ValueError(f'Unrecognized key {key}')

--- a/src/vivarium_ciff_sam/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/branches/scenarios.yaml
@@ -3,5 +3,4 @@ random_seed_count: 100
 
 branches:
   - intervention:
-#      todo add treatment only scenario
-      scenario: ['baseline', 'treatment_and_prevention']
+      scenario: ['baseline', 'wasting_treatment', 'sqlns']

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -17,16 +17,17 @@ components:
             - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
             - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
 
-            - Risk('risk_factor.wasting_non_treatment')
-            - RiskEffect('risk_factor.wasting_non_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.wasting_non_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
-            - RiskEffect('risk_factor.wasting_non_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - Risk('risk_factor.wasting_treatment')
+            - RiskEffect('risk_factor.wasting_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - RiskEffect('risk_factor.wasting_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
+            - RiskEffect('risk_factor.wasting_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
 
     vivarium_ciff_sam:
         components:
             - ChildWasting()
             - SQLNSTreatment()
-            - Intervention()
+            - SQLNSIntervention()
+            - WastingTreatmentIntervention()
             - DisabilityObserver('wasting')
             - MortalityObserver('wasting')
             - DiseaseObserver('diarrheal_diseases', 'wasting')
@@ -49,7 +50,7 @@ configuration:
         random_seed: 0
     time:
         start:
-            year: 2022
+            year: 2021
             month: 1
             day: 1
         end:

--- a/src/vivarium_ciff_sam/utilities.py
+++ b/src/vivarium_ciff_sam/utilities.py
@@ -82,6 +82,13 @@ def delete_if_exists(*paths: Union[Path, List[Path]], confirm=False):
 #     return data
 
 
+def get_norm_from_quantiles(mean: float, lower: float, upper: float,
+                            quantiles: Tuple[float, float] = (0.025, 0.975)) -> stats.norm:
+    stdnorm_quantiles = stats.norm.ppf(quantiles)
+    sd = (upper - lower) / (stdnorm_quantiles[1] - stdnorm_quantiles[0])
+    return stats.norm(loc=mean, scale=sd)
+
+
 def get_lognorm_from_quantiles(median: float, lower: float, upper: float,
                                quantiles: Tuple[float, float] = (0.025, 0.975)) -> stats.lognorm:
     """Returns a frozen lognormal distribution with the specified median, such that


### PR DESCRIPTION
The primary task of this change is implement the alternative wasting treatment intervention. This is done by updating the Wasting Treatment risk factor in the Artifact from a dichotomous risk (untreated, treated) to an ordered polytomous risk (untreated, baseline treatment, alternative treatment). This breaks down as cat1 untreated, cat2 baseline, and cat3 alternative. 

The exposure in the artifact is the same as before, except for the addition of cat3 with no exposure (since this reflects the baseline scenario). 

Relative risks (and pafs) are calculated using the same equations as before, but they are explicitly written out. The "TMREL" for calculating these values is cat2 (baseline treatment), just as before. 

Specific changes:
- Split Intervention component into separate components for each intervention
- Changed how Scenario constants operate. Instead of strings, they are objects that contain information about which interventions should be applied
- Added wasting treatment intervention. This intervention only needs to affect coverage/exposure, since the RR/PAF will take care of the rest.
- Renamed TX_EFFICIENCY and TX_COVERAGE constants to refer to baseline scenario explicitly
- Renamed "wasting non-treatment" keys to "wasting treatment" to reduce confusion
- Added 'risk_factor.wasting_treatment.categories' key to Artifact which is unused, but might be a useful reference
- Updated to start date from 2022/01/01 to 2021/01/01 per Abie
- Updated the distribution creation code to use a new utility function to calculate parameters explicitly from parameters in the documentation rather than calculating the on the side.