### PR TITLE
Feature/x factor configurability

### DIFF
--- a/src/vivarium_ciff_sam/components/__init__.py
+++ b/src/vivarium_ciff_sam/components/__init__.py
@@ -1,3 +1,4 @@
+from vivarium_ciff_sam.components.disease_effect import DiseaseEffect
 from vivarium_ciff_sam.components.intervention import SQLNSIntervention, WastingTreatmentIntervention
 from vivarium_ciff_sam.components.observers import (CategoricalRiskObserver, DisabilityObserver, DiseaseObserver,
                                                     MortalityObserver)

--- a/src/vivarium_ciff_sam/components/disease_effect.py
+++ b/src/vivarium_ciff_sam/components/disease_effect.py
@@ -1,0 +1,82 @@
+from typing import Dict
+
+from vivarium.framework.engine import Builder
+from vivarium.framework.population import PopulationView
+from vivarium_public_health.utilities import EntityString, TargetString
+
+
+class DiseaseEffect:
+    """A component to set a value based on a state in a cause model
+
+    .. code-block:: yaml
+
+       configuration:
+           effect_of_risk_on_affected_risk:
+               exposure_parameters: 2
+               incidence_rate: 10
+
+    """
+
+    configuration_defaults = {
+        'effect_of_cause_on_target': {
+            'measure': {
+                'state': None,
+            }
+        }
+    }
+
+    def __init__(self, cause: str, target: str):
+        """
+        Parameters
+        ----------
+        risk :
+            Type and name of risk factor, supplied in the form
+            "risk_type.risk_name" where risk_type should be singular (e.g.,
+            risk_factor instead of risk_factors).
+        target :
+            Type, name, and target rate of entity to be affected by risk factor,
+            supplied in the form "entity_type.entity_name.measure"
+            where entity_type should be singular (e.g., cause instead of causes).
+        """
+        self.cause = EntityString(cause)
+        self.target = TargetString(target)
+        self.configuration_defaults = {
+            f'effect_of_{self.cause.name}_on_{self.target.name}': {
+                self.target.measure: DiseaseEffect.configuration_defaults['effect_of_cause_on_target']['measure']
+            }
+        }
+
+    @property
+    def name(self):
+        return f'risk_effect.{self.cause}.{self.target}'
+
+    @property
+    def initial_state_column_name(self):
+        return f'initial_{self.cause.name}'
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder):
+        self.effect_of_cause_on_target = self.get_effect_of_cause_on_target(builder)
+        self.register_target_modifier(builder)
+        self.population_view = self.get_population_view(builder)
+
+    def get_effect_of_cause_on_target(self, builder: Builder) -> Dict[str, float]:
+        effect_block = builder.configuration[f'effect_of_{self.cause.name}_on_{self.target.name}'][self.target.measure]
+        return effect_block
+
+    def register_target_modifier(self, builder: Builder) -> None:
+        builder.value.register_value_modifier(f'{self.target.name}.{self.target.measure}',
+                                              modifier=self.adjust_target,
+                                              requires_columns=['age', 'sex', f'initial_{self.cause.name}'])
+
+    def get_population_view(self, builder: Builder) -> PopulationView:
+        return builder.population.get_view(self.initial_state_column_name)
+
+    def adjust_target(self, index, target):
+        pop = self.population_view.get(index)[self.initial_state_column_name]
+        for state, value in self.effect_of_cause_on_target.items():
+            target[pop == state] = value
+        return target
+
+    def __repr__(self):
+        return f"RiskEffect(risk={self.cause}, target={self.target})"

--- a/src/vivarium_ciff_sam/constants/data_values.py
+++ b/src/vivarium_ciff_sam/constants/data_values.py
@@ -58,7 +58,7 @@ class __Wasting(NamedTuple):
 
     # Untreated time to recovery in days
     MAM_UX_RECOVERY_TIME: float = 63.0
-    DEFAULT_MILD_WASTING_UX_RECOVERY_TIME: float = 1000.0
+    DEFAULT_MILD_WASTING_UX_RECOVERY_TIME: float = 1_000.0
 
     # Treated time to recovery in days
     SAM_TX_RECOVERY_TIME_OVER_6MO: float = 48.3

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -36,6 +36,8 @@ components:
             - LowBirthWeight()
             - ShortGestation()
 
+            - DiseaseEffect('risk_factor.child_wasting', 'risk_factor.x_factor.exposure_parameters')
+
             - SQLNSTreatment()
 
             - SQLNSIntervention()
@@ -72,7 +74,7 @@ configuration:
             day: 31
         step_size: 0.5 # Days
     population:
-        population_size: 10000
+        population_size: 10_000
         age_start: 0
         age_end: 5
         exit_age: 5
@@ -81,7 +83,14 @@ configuration:
         scenario: 'baseline'
 
     child_wasting:
-        mild_child_wasting_untreated_recovery_time: 1000
+        mild_child_wasting_untreated_recovery_time: 1_000
+
+    effect_of_child_wasting_on_x_factor:
+        exposure_parameters:
+            cat1: 0.99
+            cat2: 0.85
+            cat3: 0.3
+            cat4: 0.01
 
     effect_of_x_factor_on_mild_child_wasting:
         incidence_rate:

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -87,10 +87,10 @@ configuration:
 
     effect_of_child_wasting_on_x_factor:
         exposure_parameters:
-            cat1: 0.99
-            cat2: 0.85
-            cat3: 0.3
-            cat4: 0.01
+            severe_acute_malnutrition: 0.99
+            moderate_acute_malnutrition: 0.85
+            mild_child_wasting: 0.3
+            susceptible_to_child_wasting: 0.01
 
     effect_of_x_factor_on_mild_child_wasting:
         incidence_rate:


### PR DESCRIPTION
Makes x-factor exposure dependent on initial wasting state. This is a bit messy, since there is a threshold value that is set by the `x-factor` Risk component, which is completely overwritten by this new component (by design), so that should maybe be stripped out. 

Required me to have the RiskModel component for Wasting create a new column to store its initialization state in, which is a bit annoying. I tried to have the New component keep track of the initial value, but couldn't get it to work.