### PR TITLE
reorder wasting states to be in order of decreasing severity

### DIFF
--- a/src/vivarium_ciff_sam/components/wasting.py
+++ b/src/vivarium_ciff_sam/components/wasting.py
@@ -183,7 +183,7 @@ def ChildWasting():
     return RiskModel(
         models.WASTING.MODEL_NAME,
         get_data_functions={'cause_specific_mortality_rate': lambda *_: 0},
-        states=[tmrel, mild, moderate, severe]
+        states=[severe, moderate, mild, tmrel]
     )
 
 

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -85,10 +85,10 @@ configuration:
         scenario: 'baseline'
 
     child_wasting:
-        mild_child_wasting_untreated_recovery_time: 27
+        mild_child_wasting_untreated_recovery_time: 30
 
     x_factor:
-        exposure: 0.32
+        exposure: 0.5
 
     effect_of_x_factor_on_mild_child_wasting:
         incidence_rate:


### PR DESCRIPTION
This forces the prevalence to obey the rule that if `a` is in SAM, `b` is in MAM, `c` is in mild, and `d` is in TMREL, `propensity(a) < propensity(b) < propensity(c) < propensity(d)`, which is required, since x-factor uses the same propensity.