### PR TITLE
update conditional x-factor exposure for paf calculation

### DIFF
--- a/src/vivarium_ciff_sam/components/__init__.py
+++ b/src/vivarium_ciff_sam/components/__init__.py
@@ -4,4 +4,4 @@ from vivarium_ciff_sam.components.observers import (CategoricalRiskObserver, Dis
 from vivarium_ciff_sam.components.lbwsg import LowBirthWeight, ShortGestation
 from vivarium_ciff_sam.components.treatment import SQLNSTreatment, WastingTreatment
 from vivarium_ciff_sam.components.wasting import ChildWasting
-from vivarium_ciff_sam.components.x_factor import XFactorExposure
+from vivarium_ciff_sam.components.x_factor import XFactorExposure, XFactorEffect

--- a/src/vivarium_ciff_sam/components/x_factor.py
+++ b/src/vivarium_ciff_sam/components/x_factor.py
@@ -1,7 +1,10 @@
+from typing import Dict
+
 from vivarium.framework.engine import Builder
+from vivarium.framework.lookup import LookupTable
 from vivarium.framework.randomness import RandomnessStream
 
-from vivarium_public_health.risks import Risk
+from vivarium_public_health.risks import Risk, RiskEffect
 
 
 class XFactorExposure(Risk):
@@ -19,3 +22,47 @@ class XFactorExposure(Risk):
 
     def register_simulant_initializer(self, builder: Builder) -> None:
         pass
+
+
+class XFactorEffect(RiskEffect):
+
+    configuration_defaults = {
+        'effect_of_risk_on_target': {
+            'conditional_exposure': 0.0,
+            'measure': {
+                'relative_risk': None,
+                'mean': None,
+                'se': None,
+                'log_mean': None,
+                'log_se': None,
+                'tau_squared': None
+            }
+        }
+    }
+
+    def __init__(self, target: str):
+        super().__init__('risk_factor.x_factor', target)
+
+    ##########################
+    # Initialization methods #
+    ##########################
+
+    def get_configuration_defaults(self) -> Dict[str, Dict]:
+        return {
+            f'effect_of_{self.risk.name}_on_{self.target.name}': {
+                'conditional_exposure': XFactorEffect.configuration_defaults['effect_of_risk_on_target']['exposure'],
+                self.target.measure: XFactorEffect.configuration_defaults['effect_of_risk_on_target']['measure']
+            }
+        }
+
+    #################
+    # Setup methods #
+    #################
+
+    def get_population_attributable_fraction_source(self, builder: Builder) -> LookupTable:
+        source_key = f'effect_of_{self.risk.name}_on_{self.target.name}'
+        exposure = builder.configuration[source_key]['conditional_exposure']
+        rr = builder.configuration[source_key][self.target.measure]['relative_risk']
+
+        paf = exposure * (rr - 1) / (exposure * (rr - 1) + 1)
+        return builder.lookup.build_table(paf, key_columns=['sex'], parameter_columns=['age', 'year'])

--- a/src/vivarium_ciff_sam/components/x_factor.py
+++ b/src/vivarium_ciff_sam/components/x_factor.py
@@ -50,8 +50,10 @@ class XFactorEffect(RiskEffect):
     def get_configuration_defaults(self) -> Dict[str, Dict]:
         return {
             f'effect_of_{self.risk.name}_on_{self.target.name}': {
-                'conditional_exposure': XFactorEffect.configuration_defaults['effect_of_risk_on_target']['exposure'],
-                self.target.measure: XFactorEffect.configuration_defaults['effect_of_risk_on_target']['measure']
+                'conditional_exposure':
+                    XFactorEffect.configuration_defaults['effect_of_risk_on_target']['conditional_exposure'],
+                self.target.measure:
+                    XFactorEffect.configuration_defaults['effect_of_risk_on_target']['measure']
             }
         }
 

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -94,9 +94,11 @@ configuration:
         incidence_rate:
             relative_risk: 1.0
     effect_of_x_factor_on_mild_child_wasting_to_moderate_acute_malnutrition:
+        conditional_exposure: 0.54
         transition_rate:
             relative_risk: 3.16
     effect_of_x_factor_on_moderate_acute_malnutrition_to_severe_acute_malnutrition:
+        conditional_exposure: 0.77
         transition_rate:
             relative_risk: 3.16
 

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -98,7 +98,7 @@ configuration:
         transition_rate:
             relative_risk: 3.16
     effect_of_x_factor_on_moderate_acute_malnutrition_to_severe_acute_malnutrition:
-        conditional_exposure: 0.77
+        conditional_exposure: 0.78
         transition_rate:
             relative_risk: 3.16
 

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -23,10 +23,6 @@ components:
 
             - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
 
-            - RiskEffect('risk_factor.x_factor', 'risk_factor.mild_child_wasting.incidence_rate')
-            - RiskEffect('risk_factor.x_factor', 'risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
-            - RiskEffect('risk_factor.x_factor', 'risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
-
             - Risk('risk_factor.low_birth_weight_and_short_gestation')
 
     vivarium_ciff_sam:
@@ -36,6 +32,8 @@ components:
             - ShortGestation()
 
             - XFactorExposure()
+            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
+            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
 
             - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
             - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
@@ -90,9 +88,6 @@ configuration:
     x_factor:
         exposure: 0.5
 
-    effect_of_x_factor_on_mild_child_wasting:
-        incidence_rate:
-            relative_risk: 1.0
     effect_of_x_factor_on_mild_child_wasting_to_moderate_acute_malnutrition:
         conditional_exposure: 0.54
         transition_rate:


### PR DESCRIPTION
The exposure we actually need for paf calculation is the exposure in the source state, not the overall exposure.