### PR TITLE
calculate lbwsg paf

### DIFF
--- a/src/vivarium_ciff_sam/constants/data_keys.py
+++ b/src/vivarium_ciff_sam/constants/data_keys.py
@@ -1,5 +1,6 @@
 from typing import NamedTuple
 
+import pandas as pd
 from vivarium_public_health.utilities import TargetString
 
 
@@ -263,6 +264,9 @@ class __LowBirthWeightShortGestation(NamedTuple):
     PAF: TargetString = 'risk_factor.low_birth_weight_and_short_gestation.population_attributable_fraction'
 
     # Useful keys not for the artifact - distinguished by not using the colon type declaration
+    TMREL_CATEGORIES = {'cat53', 'cat54', 'cat55', 'cat56'}
+    TMREL_GESTATIONAL_AGE_INTERVAL = pd.Interval(38.0, 42.0)
+    TMREL_BIRTH_WEIGHT_INTERVAL = pd.Interval(3500.0, 4500.0)
 
     @property
     def name(self):


### PR DESCRIPTION
Use Monte Carlo techniques to calculate LBWSG PAFs by.
- loading LBWSG categorical exposure
- generating a "population" and randomly sampling their categorical LBWSG exposure
- transforming that categorical exposure into continuous birth-weight and gestational age exposures
- computing their relative risk from their expsoure
- computing the mean rr and then the paf.


Additionally
- Fix loading interpolators from artifact
- Refactor LBWSG TMREL categories into the data_keys constants file
- Remove `pd.IntervalIndex` from artifact data, since it doesn't serialize well