### PR TITLE
Bugfix/vct dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Once you have all three installed, you should open up your normal shell
 You'll then make an environment, clone this repository, then install
 all necessary requirements as follows::
 
-  :~$ conda create --name=vivarium_ciff_sam python=3.6
+  :~$ conda create --name=vivarium_ciff_sam python=3.8
   ...conda will download python and base dependencies...
   :~$ conda activate vivarium_ciff_sam
   (vivarium_ciff_sam) :~$ git clone https://github.com/ihmeuw/vivarium_ciff_sam.git

--- a/src/vivarium_ciff_sam/tools/make_artifacts.py
+++ b/src/vivarium_ciff_sam/tools/make_artifacts.py
@@ -15,15 +15,16 @@ from pathlib import Path
 from typing import Tuple, Union
 from loguru import logger
 
-import vivarium_cluster_tools as vct
-
 from vivarium_ciff_sam.constants import data_keys, metadata
 from vivarium_ciff_sam.utilities import sanitize_location, delete_if_exists, len_longest_location
 from vivarium_ciff_sam.tools.app_logging import add_logging_sink, decode_status
 
 
 def running_from_cluster() -> bool:
+
+    import vivarium_cluster_tools as vct
     on_cluster = True
+
     try:
         vct.get_cluster_name()
     except:
@@ -77,6 +78,8 @@ def build_artifacts(location: str, output_dir: str, append: bool, replace_keys: 
     verbose
         How noisy the logger should be.
     """
+
+    import vivarium_cluster_tools as vct
     output_dir = Path(output_dir)
     vct.mkdir(output_dir, parents=True, exists_ok=True)
 


### PR DESCRIPTION
## Localize vct imports for arrifact building
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*:bugfix
- *JIRA issue*: [MIC-2785](https://jira.ihme.washington.edu/browse/MIC-2785)
- *Research reference*: N/A

Removes vct as adependency to make results.
Updates the README to set python 3.8 as the preferred python version.

### Verification and Testing
Ran make_results without vct in the environment.