### PR TITLE
Feature/lbwsg observers

### DIFF
--- a/src/vivarium_ciff_sam/components/__init__.py
+++ b/src/vivarium_ciff_sam/components/__init__.py
@@ -1,8 +1,8 @@
 from vivarium_ciff_sam.components.intervention import SQLNSIntervention, WastingTreatmentIntervention
-from vivarium_ciff_sam.components.observers import (CategoricalRiskObserver, DisabilityObserver, DiseaseObserver,
-                                                    MortalityObserver)
-from vivarium_ciff_sam.components.lbwsg import (AffectedUnmodeledCause, LowBirthWeight, ShortGestation, LBWSGRisk,
-                                                LBWSGRiskEffect)
+from vivarium_ciff_sam.components.observers import (BirthObserver, CategoricalRiskObserver, DisabilityObserver,
+                                                    DiseaseObserver, MortalityObserver)
+from vivarium_ciff_sam.components.lbwsg import (AffectedUnmodeledCause, LBWSGRisk, LBWSGRiskEffect, LBWSGSubRisk,
+                                                LowBirthWeight, ShortGestation)
 from vivarium_ciff_sam.components.treatment import SQLNSTreatment, WastingTreatment
 from vivarium_ciff_sam.components.wasting import ChildWasting
 from vivarium_ciff_sam.components.x_factor import XFactorExposure, XFactorEffect

--- a/src/vivarium_ciff_sam/components/observers.py
+++ b/src/vivarium_ciff_sam/components/observers.py
@@ -2,15 +2,18 @@ import itertools
 from typing import Callable, Dict, Iterable, List, Tuple, Union
 
 import pandas as pd
+from vivarium import ConfigTree
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
-from vivarium_public_health.metrics import (MortalityObserver as MortalityObserver_,
+from vivarium.framework.population import PopulationView
+from vivarium.framework.time import Time
+from vivarium.framework.values import Pipeline
+from vivarium_public_health.metrics import (utilities,
+                                            MortalityObserver as MortalityObserver_,
                                             DisabilityObserver as DisabilityObserver_,
                                             DiseaseObserver as DiseaseObserver_,
                                             CategoricalRiskObserver as CategoricalRiskObserver_)
-from vivarium_public_health.metrics.utilities import (get_deaths, get_state_person_time, get_transition_count,
-                                                      get_years_lived_with_disability, get_years_of_life_lost,
-                                                      TransitionString)
+from vivarium_public_health.metrics.utilities import QueryString, TransitionString
 
 from vivarium_ciff_sam.constants import models, results, data_keys
 
@@ -198,10 +201,13 @@ class MortalityObserver(MortalityObserver_):
     def metrics(self, index: pd.Index, metrics: Dict[str, float]) -> Dict[str, float]:
         pop = self.population_view.get(index)
         pop.loc[pop.exit_time.isnull(), 'exit_time'] = self.clock()
+        pop.loc[
+            pop['cause_of_death'].isin(models.AFFECTED_UNMODELED_CAUSES), 'cause_of_death'
+        ] = data_keys.AFFECTED_UNMODELED_CAUSES.name
 
         measure_getters = (
-            (get_deaths, (self.causes,)),
-            (get_years_of_life_lost, (self.life_expectancy, self.causes)),
+            (utilities.get_deaths, (self.causes,)),
+            (utilities.get_years_of_life_lost, (self.life_expectancy, self.causes)),
         )
 
         for labels, pop_in_group in self.stratifier.group(pop):
@@ -247,7 +253,7 @@ class DisabilityObserver(DisabilityObserver_):
         for labels, pop_in_group in self.stratifier.group(pop):
             base_args = (pop_in_group, self.config.to_dict(), self.clock().year, self.step_size(), self.age_bins,
                          self.disability_weight_pipelines, self.causes)
-            measure_data = self.stratifier.update_labels(get_years_lived_with_disability(*base_args), labels)
+            measure_data = self.stratifier.update_labels(utilities.get_years_lived_with_disability(*base_args), labels)
             self.years_lived_with_disability.update(measure_data)
 
         # TODO remove stratification by wasting state of ylds due to PEM?
@@ -277,8 +283,9 @@ class DiseaseObserver(DiseaseObserver_):
         for labels, pop_in_group in self.stratifier.group(pop):
             for state in self.states:
                 # noinspection PyTypeChecker
-                state_person_time_this_step = get_state_person_time(pop_in_group, self.config, self.disease, state,
-                                                                    self.clock().year, event.step_size, self.age_bins)
+                state_person_time_this_step = utilities.get_state_person_time(
+                    pop_in_group, self.config, self.disease, state, self.clock().year, event.step_size, self.age_bins
+                )
                 state_person_time_this_step = self.stratifier.update_labels(state_person_time_this_step, labels)
                 self.person_time.update(state_person_time_this_step)
 
@@ -293,8 +300,8 @@ class DiseaseObserver(DiseaseObserver_):
             for transition in self.transitions:
                 transition = TransitionString(transition)
                 # noinspection PyTypeChecker
-                transition_counts_this_step = get_transition_count(pop_in_group, self.config, self.disease, transition,
-                                                                   event.time, self.age_bins)
+                transition_counts_this_step = utilities.get_transition_count(pop_in_group, self.config, self.disease,
+                                                                             transition, event.time, self.age_bins)
                 transition_counts_this_step = self.stratifier.update_labels(transition_counts_this_step, labels)
                 self.counts.update(transition_counts_this_step)
 
@@ -331,7 +338,169 @@ class CategoricalRiskObserver(CategoricalRiskObserver_):
         for labels, pop_in_group in self.stratifier.group(pop):
             for category in self.categories:
                 # noinspection PyTypeChecker
-                state_person_time_this_step = get_state_person_time(pop_in_group, self.config, self.risk, category,
-                                                                    self.clock().year, event.step_size, self.age_bins)
+                state_person_time_this_step = utilities.get_state_person_time(
+                    pop_in_group, self.config, self.risk, category, self.clock().year, event.step_size, self.age_bins
+                )
                 state_person_time_this_step = self.stratifier.update_labels(state_person_time_this_step, labels)
                 self.person_time.update(state_person_time_this_step)
+
+
+class BirthObserver:
+    configuration_defaults = {
+        'metrics': {
+            'birth': {
+                'by_age': False,
+                'by_year': False,
+                'by_sex': False,
+            }
+        }
+    }
+
+    def __init__(self, stratify_by_wasting: str = 'False', stratify_by_sq_lns: str = 'False',
+                 stratify_by_wasting_treatment: str = 'False', stratify_by_x_factor: str = 'False',
+                 stratify_by_stunting: str = 'False'):
+        self.configuration_defaults = self._get_configuration_defaults()
+        self.stratifier = ResultsStratifier(self.name, stratify_by_wasting, stratify_by_sq_lns,
+                                            stratify_by_wasting_treatment, stratify_by_x_factor, stratify_by_stunting)
+
+        self.tracked_column_name = 'tracked'
+        self.entrance_time_column_name = 'entrance_time'
+
+        self.birth_weight_pipeline_name = 'low_birth_weight.exposure'
+        self.metrics_pipeline_name = 'metrics'
+
+    def __repr__(self):
+        return 'BirthObserver()'
+
+    ##########################
+    # Initialization methods #
+    ##########################
+
+    # noinspection PyMethodMayBeStatic
+    def _get_configuration_defaults(self) -> Dict[str, Dict]:
+        return {
+            'metrics': {
+                f'birth': BirthObserver.configuration_defaults['metrics']['birth']
+            }
+        }
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def sub_components(self) -> List[ResultsStratifier]:
+        return [self.stratifier]
+
+    @property
+    def name(self):
+        return 'birth_observer'
+
+    #################
+    # Setup methods #
+    #################
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder) -> None:
+        self.clock = self._get_clock(builder)
+        self.configuration = self._get_configuration(builder)
+        self.start_time = self.clock()
+        self.age_bins = self._get_age_bins(builder)
+        self.pipelines = self._get_pipelines(builder)
+        self.population_view = self._get_population_view(builder)
+
+        self._register_metrics_modifier(builder)
+
+    # noinspection PyMethodMayBeStatic
+    def _get_clock(self, builder: Builder) -> Callable[[], Time]:
+        return builder.time.clock()
+
+    # noinspection PyMethodMayBeStatic
+    def _get_configuration(self, builder: Builder) -> ConfigTree:
+        return builder.configuration.metrics.birth
+
+    # noinspection PyMethodMayBeStatic
+    def _get_age_bins(self, builder: Builder) -> pd.DataFrame:
+        return utilities.get_age_bins(builder)
+
+    def _get_pipelines(self, builder: Builder) -> Dict[str, Pipeline]:
+        return {
+            self.birth_weight_pipeline_name: builder.value.get_value(self.birth_weight_pipeline_name),
+        }
+
+    def _get_population_view(self, builder: Builder) -> PopulationView:
+        return builder.population.get_view(['sex', self.tracked_column_name, self.entrance_time_column_name])
+
+    def _register_metrics_modifier(self, builder: Builder) -> None:
+        builder.value.register_value_modifier(
+            self.metrics_pipeline_name,
+            self._metrics,
+            requires_columns=[self.entrance_time_column_name],
+            requires_values=[self.birth_weight_pipeline_name]
+        )
+
+    ##################################
+    # Pipeline sources and modifiers #
+    ##################################
+
+    # noinspection PyUnusedLocal
+    def _metrics(self, index: pd.Index, metrics: Dict) -> Dict:
+        pop = pd.concat(
+            [self.population_view.get(index), self.pipelines[self.birth_weight_pipeline_name](index)],
+            axis=1
+        )
+
+        measure_getters = (
+            (self._get_births, ()),
+            (self._get_birth_weight_sum, ()),
+            (self._get_births, (results.LOW_BIRTH_WEIGHT_CUTOFF,)),
+        )
+
+        for labels, pop_in_group in self.stratifier.group(pop):
+            args = (pop_in_group, self.configuration.to_dict(), self.start_time, self.clock(), self.age_bins)
+
+            for measure_getter, extra_args in measure_getters:
+                measure_data = measure_getter(*args, *extra_args)
+                measure_data = self.stratifier.update_labels(measure_data, labels)
+                metrics.update(measure_data)
+
+    def _get_births(self, pop: pd.DataFrame, configuration: Dict, start_time: Time, end_time: Time,
+                    age_bins: pd.DataFrame, cutoff_weight: float = None) -> Dict[str, float]:
+        if cutoff_weight:
+            birth_weight_filter = (
+                QueryString('{column} <= {cutoff}')
+                .format(column=f'`{self.birth_weight_pipeline_name}`', cutoff=cutoff_weight)
+            )
+            measure = 'low_weight_births'
+        else:
+            birth_weight_filter = QueryString('tracked in (True, False)')
+            measure = 'total_births'
+
+        base_key = utilities.get_output_template(**configuration).substitute(measure=measure)
+        time_spans = utilities.get_time_iterable(configuration, start_time, end_time)
+
+        births = {}
+        for year, (year_start, year_end) in time_spans:
+            born_in_span = pop[(year_start <= pop.entrance_time) & (pop.entrance_time < year_end)]
+            year_key = base_key.substitute(year=year)
+            group_births = utilities.get_group_counts(born_in_span, birth_weight_filter, year_key, configuration,
+                                                      age_bins)
+            births.update(group_births)
+        return births
+
+    def _get_birth_weight_sum(self, pop: pd.DataFrame, configuration: Dict, start_time: Time, end_time: Time,
+                              age_bins: pd.DataFrame) -> Dict[str, float]:
+
+        base_filter = QueryString('tracked in (True, False)')
+        base_key = utilities.get_output_template(**configuration).substitute(measure='birth_weight_sum')
+        time_spans = utilities.get_time_iterable(configuration, start_time, end_time)
+
+        birth_weight_sum = {}
+        for year, (year_start, year_end) in time_spans:
+            born_in_span = pop[(year_start <= pop.entrance_time) & (pop.entrance_time < year_end)]
+            year_key = base_key.substitute(year=year)
+            group_birth_weight_sums = utilities.get_group_counts(born_in_span, base_filter, year_key, configuration,
+                                                                 age_bins,
+                                                                 lambda df: df[self.birth_weight_pipeline_name].sum())
+            birth_weight_sum.update(group_birth_weight_sums)
+        return birth_weight_sum

--- a/src/vivarium_ciff_sam/constants/data_keys.py
+++ b/src/vivarium_ciff_sam/constants/data_keys.py
@@ -281,7 +281,7 @@ class __LowBirthWeightShortGestation(NamedTuple):
 LBWSG = __LowBirthWeightShortGestation()
 
 
-class __UnmodeledCauses(NamedTuple):
+class __AffectedUnmodeledCauses(NamedTuple):
     # Keys that will be loaded into the artifact. must have a colon type declaration
     URI_CSMR: TargetString = TargetString('cause.upper_respiratory_infections.cause_specific_mortality_rate')
     OTITIS_MEDIA_CSMR: TargetString = TargetString('cause.otitis_media.cause_specific_mortality_rate')
@@ -309,14 +309,14 @@ class __UnmodeledCauses(NamedTuple):
 
     @property
     def name(self):
-        return 'unmodeled_causes'
+        return 'affected_unmodeled_causes'
 
     @property
     def log_name(self):
-        return 'unmodeled causes'
+        return 'affected unmodeled causes'
 
 
-UNMODELED_CAUSES = __UnmodeledCauses()
+AFFECTED_UNMODELED_CAUSES = __AffectedUnmodeledCauses()
 
 
 MAKE_ARTIFACT_KEY_GROUPS = [
@@ -331,5 +331,5 @@ MAKE_ARTIFACT_KEY_GROUPS = [
     SAM_TREATMENT,
     MAM_TREATMENT,
     LBWSG,
-    UNMODELED_CAUSES,
+    AFFECTED_UNMODELED_CAUSES,
 ]

--- a/src/vivarium_ciff_sam/constants/models.py
+++ b/src/vivarium_ciff_sam/constants/models.py
@@ -65,6 +65,8 @@ CAUSE_MODELS: List[__SISModel] = [
     MEASLES,
 ]
 
+AFFECTED_UNMODELED_CAUSES = {cause.name for cause in data_keys.AFFECTED_UNMODELED_CAUSES}
+
 
 def get_risk_category(state_name: str) -> str:
     return {

--- a/src/vivarium_ciff_sam/constants/results.py
+++ b/src/vivarium_ciff_sam/constants/results.py
@@ -1,6 +1,6 @@
 import itertools
 
-from vivarium_ciff_sam.constants import models
+from vivarium_ciff_sam.constants import data_keys, models
 
 #################################
 # Results columns and variables #
@@ -31,6 +31,7 @@ DISEASE_TRANSITION_COUNT_COLUMN_TEMPLATE = '{DISEASE_TRANSITION}_event_count_in_
 WASTING_STATE_PERSON_TIME_COLUMN_TEMPLATE = '{WASTING_STATE}_person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_sam_treatment_{SAM_TREATMENT_STATE}_mam_treatment_{MAM_TREATMENT_STATE}_sq_lns_{SQLNS_STATE}_x_factor_{X_FACTOR_STATE}'
 WASTING_TRANSITION_COUNT_COLUMN_TEMPLATE = '{WASTING_TRANSITION}_event_count_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_sam_treatment_{SAM_TREATMENT_STATE}_mam_treatment_{MAM_TREATMENT_STATE}_sq_lns_{SQLNS_STATE}_x_factor_{X_FACTOR_STATE}'
 STUNTING_STATE_PERSON_TIME_COLUMN_TEMPLATE = '{STUNTING_STATE}_person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_sq_lns_{SQLNS_STATE}'
+BIRTHS_COLUMN_TEMPLATE = '{BIRTH_METRIC}_in_{YEAR}_among_{SEX}'
 
 COLUMN_TEMPLATES = {
     'population': TOTAL_POPULATION_COLUMN_TEMPLATE,
@@ -42,6 +43,7 @@ COLUMN_TEMPLATES = {
     'wasting_state_person_time': WASTING_STATE_PERSON_TIME_COLUMN_TEMPLATE,
     'wasting_transition_count': WASTING_TRANSITION_COUNT_COLUMN_TEMPLATE,
     'stunting_state_person_time': STUNTING_STATE_PERSON_TIME_COLUMN_TEMPLATE,
+    'births': BIRTHS_COLUMN_TEMPLATE,
 }
 
 NON_COUNT_TEMPLATES = [
@@ -54,6 +56,7 @@ AGE_GROUPS = ('early_neonatal', 'late_neonatal', '1-5_months', '6-11_months', '1
 STUNTING_STATES = ('cat4', 'cat3', 'cat2', 'cat1')
 TREATMENT_STATES = ('covered', 'uncovered')
 X_FACTOR_STATE = ('cat2', 'cat1')
+BIRTH_METRICS = ('total_births', 'birth_weight_sum', 'low_weight_births')
 CAUSES_OF_DEATH = (
     'other_causes',
     models.DIARRHEA.STATE_NAME,
@@ -61,6 +64,7 @@ CAUSES_OF_DEATH = (
     models.LRI.STATE_NAME,
     models.WASTING.MODERATE_STATE_NAME,
     models.WASTING.SEVERE_STATE_NAME,
+    data_keys.AFFECTED_UNMODELED_CAUSES.name
 )
 CAUSES_OF_DISABILITY = (
     models.DIARRHEA.STATE_NAME,
@@ -86,7 +90,11 @@ TEMPLATE_FIELD_MAP = {
     'SAM_TREATMENT_STATE': TREATMENT_STATES,
     'MAM_TREATMENT_STATE': TREATMENT_STATES,
     'X_FACTOR_STATE': X_FACTOR_STATE,
+    'BIRTH_METRIC': BIRTH_METRICS,
 }
+
+
+LOW_BIRTH_WEIGHT_CUTOFF = 2500.0
 
 
 # noinspection PyPep8Naming

--- a/src/vivarium_ciff_sam/data/loader.py
+++ b/src/vivarium_ciff_sam/data/loader.py
@@ -24,7 +24,7 @@ from vivarium.framework.artifact import EntityKey
 from vivarium_gbd_access import constants as gbd_constants
 from vivarium_inputs import interface
 
-from vivarium_ciff_sam.components import LBWSGRisk, LowBirthWeight, ShortGestation
+from vivarium_ciff_sam.components import LBWSGSubRisk, LowBirthWeight, ShortGestation
 from vivarium_ciff_sam.constants import data_keys, data_values, metadata, paths
 from vivarium_ciff_sam.data import utilities
 
@@ -118,27 +118,27 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.LBWSG.RELATIVE_RISK_INTERPOLATOR: load_lbwsg_interpolated_rr,
         data_keys.LBWSG.PAF: load_lbwsg_paf,
 
-        data_keys.UNMODELED_CAUSES.URI_CSMR: load_standard_data,
-        data_keys.UNMODELED_CAUSES.OTITIS_MEDIA_CSMR: load_standard_data,
-        data_keys.UNMODELED_CAUSES.MENINGITIS_CSMR: load_standard_data,
-        data_keys.UNMODELED_CAUSES.ENCEPHALITIS_CSMR: load_standard_data,
-        data_keys.UNMODELED_CAUSES.NEONATAL_PRETERM_BIRTH_CSMR: load_standard_data,
-        data_keys.UNMODELED_CAUSES.NEONATAL_ENCEPHALOPATHY_CSMR: load_standard_data,
-        data_keys.UNMODELED_CAUSES.NEONATAL_SEPSIS_CSMR: load_standard_data,
-        data_keys.UNMODELED_CAUSES.NEONATAL_JAUNDICE_CSMR: load_standard_data,
-        data_keys.UNMODELED_CAUSES.OTHER_NEONATAL_DISORDERS_CSMR: load_standard_data,
-        data_keys.UNMODELED_CAUSES.SIDS_CSMR: load_sids_csmr,
+        data_keys.AFFECTED_UNMODELED_CAUSES.URI_CSMR: load_standard_data,
+        data_keys.AFFECTED_UNMODELED_CAUSES.OTITIS_MEDIA_CSMR: load_standard_data,
+        data_keys.AFFECTED_UNMODELED_CAUSES.MENINGITIS_CSMR: load_standard_data,
+        data_keys.AFFECTED_UNMODELED_CAUSES.ENCEPHALITIS_CSMR: load_standard_data,
+        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_PRETERM_BIRTH_CSMR: load_standard_data,
+        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_ENCEPHALOPATHY_CSMR: load_standard_data,
+        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_SEPSIS_CSMR: load_standard_data,
+        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_JAUNDICE_CSMR: load_standard_data,
+        data_keys.AFFECTED_UNMODELED_CAUSES.OTHER_NEONATAL_DISORDERS_CSMR: load_standard_data,
+        data_keys.AFFECTED_UNMODELED_CAUSES.SIDS_CSMR: load_sids_csmr,
 
-        data_keys.UNMODELED_CAUSES.URI_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.UNMODELED_CAUSES.OTITIS_MEDIA_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.UNMODELED_CAUSES.MENINGITIS_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.UNMODELED_CAUSES.ENCEPHALITIS_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.UNMODELED_CAUSES.NEONATAL_PRETERM_BIRTH_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.UNMODELED_CAUSES.NEONATAL_ENCEPHALOPATHY_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.UNMODELED_CAUSES.NEONATAL_SEPSIS_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.UNMODELED_CAUSES.NEONATAL_JAUNDICE_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.UNMODELED_CAUSES.OTHER_NEONATAL_DISORDERS_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.UNMODELED_CAUSES.SIDS_RESTRICTIONS: load_unmodeled_causes_restrictions,
+        data_keys.AFFECTED_UNMODELED_CAUSES.URI_RESTRICTIONS: load_unmodeled_causes_restrictions,
+        data_keys.AFFECTED_UNMODELED_CAUSES.OTITIS_MEDIA_RESTRICTIONS: load_unmodeled_causes_restrictions,
+        data_keys.AFFECTED_UNMODELED_CAUSES.MENINGITIS_RESTRICTIONS: load_unmodeled_causes_restrictions,
+        data_keys.AFFECTED_UNMODELED_CAUSES.ENCEPHALITIS_RESTRICTIONS: load_unmodeled_causes_restrictions,
+        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_PRETERM_BIRTH_RESTRICTIONS: load_unmodeled_causes_restrictions,
+        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_ENCEPHALOPATHY_RESTRICTIONS: load_unmodeled_causes_restrictions,
+        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_SEPSIS_RESTRICTIONS: load_unmodeled_causes_restrictions,
+        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_JAUNDICE_RESTRICTIONS: load_unmodeled_causes_restrictions,
+        data_keys.AFFECTED_UNMODELED_CAUSES.OTHER_NEONATAL_DISORDERS_RESTRICTIONS: load_unmodeled_causes_restrictions,
+        data_keys.AFFECTED_UNMODELED_CAUSES.SIDS_RESTRICTIONS: load_unmodeled_causes_restrictions,
     }
     return mapping[lookup_key](lookup_key, location)
 
@@ -467,7 +467,7 @@ def load_lbwsg_interpolated_rr(key: str, location: str) -> pd.DataFrame:
     )
 
     # get category midpoints
-    def get_category_midpoints(lbwsg_type: Type[LBWSGRisk]) -> pd.Series:
+    def get_category_midpoints(lbwsg_type: Type[LBWSGSubRisk]) -> pd.Series:
         categories = get_data(f'risk_factor.{data_keys.LBWSG.name}.categories', location)
         return lbwsg_type.get_intervals_from_categories(categories).apply(lambda x: x.mid)
 
@@ -537,7 +537,7 @@ def load_lbwsg_paf(key: str, location: str) -> pd.DataFrame:
 
 
 def load_sids_csmr(key: str, location: str) -> pd.DataFrame:
-    if key == data_keys.UNMODELED_CAUSES.SIDS_CSMR:
+    if key == data_keys.AFFECTED_UNMODELED_CAUSES.SIDS_CSMR:
         key = EntityKey(key)
         entity: Cause = utilities.get_entity(key)
 
@@ -554,7 +554,7 @@ def load_sids_csmr(key: str, location: str) -> pd.DataFrame:
 
 # noinspection PyUnusedLocal
 def load_unmodeled_causes_restrictions(key: str, location: str) -> Dict:
-    if key not in data_keys.UNMODELED_CAUSES or 'restrictions' not in key:
+    if key not in data_keys.AFFECTED_UNMODELED_CAUSES or 'restrictions' not in key:
         raise ValueError(f'Unrecognized key {key}')
 
     return {

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -4,75 +4,75 @@ components:
             - BasePopulation()
             - Mortality()
             - FertilityCrudeBirthRate()
-#        disease:
-#            - SIS('diarrheal_diseases')
-#            - SIS_fixed_duration('measles', '10.0')
-#            - SIS('lower_respiratory_infections')
-#        risks:
-#            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
-#            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
-#            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
-#
-#            - Risk('risk_factor.child_stunting')
-#            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
-#            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
-#            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
-#
-#            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
-#            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
-#
-#            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
+        disease:
+            - SIS('diarrheal_diseases')
+            - SIS_fixed_duration('measles', '10.0')
+            - SIS('lower_respiratory_infections')
+        risks:
+            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
+            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
+            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
+
+            - Risk('risk_factor.child_stunting')
+            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
+            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
+            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
+
+            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
+
+            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
 
     vivarium_ciff_sam:
         components:
-#            - ChildWasting()
-#
-#            - AffectedUnmodeledCause('upper_respiratory_infections')
-#            - AffectedUnmodeledCause('otitis_media')
-#            - AffectedUnmodeledCause('meningitis')
-#            - AffectedUnmodeledCause('encephalitis')
-#            - AffectedUnmodeledCause('neonatal_preterm_birth')
-#            - AffectedUnmodeledCause('neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma')
-#            - AffectedUnmodeledCause('neonatal_sepsis_and_other_neonatal_infections')
-#            - AffectedUnmodeledCause('hemolytic_disease_and_other_neonatal_jaundice')
-#            - AffectedUnmodeledCause('other_neonatal_disorders')
-#            - AffectedUnmodeledCause('sudden_infant_death_syndrome')
+            - ChildWasting()
+
+            - AffectedUnmodeledCause('upper_respiratory_infections')
+            - AffectedUnmodeledCause('otitis_media')
+            - AffectedUnmodeledCause('meningitis')
+            - AffectedUnmodeledCause('encephalitis')
+            - AffectedUnmodeledCause('neonatal_preterm_birth')
+            - AffectedUnmodeledCause('neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma')
+            - AffectedUnmodeledCause('neonatal_sepsis_and_other_neonatal_infections')
+            - AffectedUnmodeledCause('hemolytic_disease_and_other_neonatal_jaundice')
+            - AffectedUnmodeledCause('other_neonatal_disorders')
+            - AffectedUnmodeledCause('sudden_infant_death_syndrome')
 
             - LBWSGRisk()
             - LowBirthWeight()
             - ShortGestation()
-#            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.upper_respiratory_infections.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.otitis_media.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.meningitis.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.encephalitis.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.neonatal_preterm_birth.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.neonatal_sepsis_and_other_neonatal_infections.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.hemolytic_disease_and_other_neonatal_jaundice.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.other_neonatal_disorders.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.sudden_infant_death_syndrome.excess_mortality_rate')
-#
-#            - XFactorExposure()
-#            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
-#            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
-#
-#            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
-#            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
-#            - SQLNSTreatment()
-#
-#            - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
-#            - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')
-#            - SQLNSIntervention()
+            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.upper_respiratory_infections.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.otitis_media.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.meningitis.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.encephalitis.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.neonatal_preterm_birth.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.neonatal_sepsis_and_other_neonatal_infections.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.hemolytic_disease_and_other_neonatal_jaundice.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.other_neonatal_disorders.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.sudden_infant_death_syndrome.excess_mortality_rate')
 
-#            - DisabilityObserver('wasting')
-#            - MortalityObserver('wasting')
-#            - DiseaseObserver('diarrheal_diseases', 'wasting')
-#            - DiseaseObserver('measles', 'wasting')
-#            - DiseaseObserver('lower_respiratory_infections', 'wasting')
-#            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
-#            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
+            - XFactorExposure()
+            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
+            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
+
+            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
+            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
+            - SQLNSTreatment()
+
+            - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
+            - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')
+            - SQLNSIntervention()
+
+            - DisabilityObserver('wasting')
+            - MortalityObserver('wasting')
+            - DiseaseObserver('diarrheal_diseases', 'wasting')
+            - DiseaseObserver('measles', 'wasting')
+            - DiseaseObserver('lower_respiratory_infections', 'wasting')
+            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
+            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
             - BirthObserver()
 
 configuration:
@@ -93,15 +93,15 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2022
-            month: 1
-            day: 10
+            year: 2026
+            month: 12
+            day: 31
         step_size: 0.5 # Days
     population:
         population_size: 10_000
         age_start: 0
-        age_end: 0.1
-        exit_age: 0.1
+        age_end: 5
+        exit_age: 5
 
     intervention:
         scenario: 'baseline'

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -4,76 +4,76 @@ components:
             - BasePopulation()
             - Mortality()
             - FertilityCrudeBirthRate()
-        disease:
-            - SIS('diarrheal_diseases')
-            - SIS_fixed_duration('measles', '10.0')
-            - SIS('lower_respiratory_infections')
-        risks:
-            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
-            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
-            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
-
-            - Risk('risk_factor.child_stunting')
-            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
-            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
-            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
-
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
-
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
-
-            - Risk('risk_factor.low_birth_weight_and_short_gestation')
+#        disease:
+#            - SIS('diarrheal_diseases')
+#            - SIS_fixed_duration('measles', '10.0')
+#            - SIS('lower_respiratory_infections')
+#        risks:
+#            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
+#            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
+#            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
+#
+#            - Risk('risk_factor.child_stunting')
+#            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
+#            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
+#            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
+#
+#            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
+#            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
+#
+#            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
 
     vivarium_ciff_sam:
         components:
-            - ChildWasting()
+#            - ChildWasting()
+#
+#            - AffectedUnmodeledCause('upper_respiratory_infections')
+#            - AffectedUnmodeledCause('otitis_media')
+#            - AffectedUnmodeledCause('meningitis')
+#            - AffectedUnmodeledCause('encephalitis')
+#            - AffectedUnmodeledCause('neonatal_preterm_birth')
+#            - AffectedUnmodeledCause('neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma')
+#            - AffectedUnmodeledCause('neonatal_sepsis_and_other_neonatal_infections')
+#            - AffectedUnmodeledCause('hemolytic_disease_and_other_neonatal_jaundice')
+#            - AffectedUnmodeledCause('other_neonatal_disorders')
+#            - AffectedUnmodeledCause('sudden_infant_death_syndrome')
 
-            - AffectedUnmodeledCause('upper_respiratory_infections')
-            - AffectedUnmodeledCause('otitis_media')
-            - AffectedUnmodeledCause('meningitis')
-            - AffectedUnmodeledCause('encephalitis')
-            - AffectedUnmodeledCause('neonatal_preterm_birth')
-            - AffectedUnmodeledCause('neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma')
-            - AffectedUnmodeledCause('neonatal_sepsis_and_other_neonatal_infections')
-            - AffectedUnmodeledCause('hemolytic_disease_and_other_neonatal_jaundice')
-            - AffectedUnmodeledCause('other_neonatal_disorders')
-            - AffectedUnmodeledCause('sudden_infant_death_syndrome')
-
+            - LBWSGRisk()
             - LowBirthWeight()
             - ShortGestation()
-            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.upper_respiratory_infections.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.otitis_media.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.meningitis.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.encephalitis.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.neonatal_preterm_birth.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.neonatal_sepsis_and_other_neonatal_infections.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.hemolytic_disease_and_other_neonatal_jaundice.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.other_neonatal_disorders.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.sudden_infant_death_syndrome.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.upper_respiratory_infections.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.otitis_media.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.meningitis.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.encephalitis.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.neonatal_preterm_birth.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.neonatal_sepsis_and_other_neonatal_infections.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.hemolytic_disease_and_other_neonatal_jaundice.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.other_neonatal_disorders.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.sudden_infant_death_syndrome.excess_mortality_rate')
+#
+#            - XFactorExposure()
+#            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
+#            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
+#
+#            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
+#            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
+#            - SQLNSTreatment()
+#
+#            - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
+#            - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')
+#            - SQLNSIntervention()
 
-            - XFactorExposure()
-            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
-            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
-
-            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
-            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
-            - SQLNSTreatment()
-
-            - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
-            - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')
-            - SQLNSIntervention()
-
-            - DisabilityObserver('wasting')
-            - MortalityObserver('wasting')
-            - DiseaseObserver('diarrheal_diseases', 'wasting')
-            - DiseaseObserver('measles', 'wasting')
-            - DiseaseObserver('lower_respiratory_infections', 'wasting')
-            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
-            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
+#            - DisabilityObserver('wasting')
+#            - MortalityObserver('wasting')
+#            - DiseaseObserver('diarrheal_diseases', 'wasting')
+#            - DiseaseObserver('measles', 'wasting')
+#            - DiseaseObserver('lower_respiratory_infections', 'wasting')
+#            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
+#            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
+            - BirthObserver()
 
 configuration:
     input_data:
@@ -93,15 +93,15 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2026
-            month: 12
-            day: 31
+            year: 2022
+            month: 1
+            day: 10
         step_size: 0.5 # Days
     population:
         population_size: 10_000
         age_start: 0
-        age_end: 5
-        exit_age: 5
+        age_end: 0.1
+        exit_age: 0.1
 
     intervention:
         scenario: 'baseline'
@@ -148,5 +148,9 @@ configuration:
             by_year: True
         child_stunting:
             by_age: True
+            by_sex: True
+            by_year: True
+        birth:
+            by_age: False
             by_sex: True
             by_year: True


### PR DESCRIPTION
## Implement birth observer
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: observers
- *JIRA issue*: <!-- [MIC2596](https://jira.ihme.washington.edu/browse/MIC-2596) -->
- *Research reference*: [Simulation output table](https://vivarium-research.readthedocs.io/en/latest/concept_models/vivarium_ciff_sam/concept_model.html?highlight=ciff#id29)

Implements the `BirthObserver` which counts births, low weight births, and total birth weight.
Notes:
- It was necessary to add the `tracked` column to the LBWSG and BirthWeight `Risk` components in order to record these values for simulants who become untracked by the end of the simulation.
- We're recording all simulants who die of LBWSG-affected causes as having the `affected_unmodeled_cause` cause of death
- Renamed `data_keys.UNMODELED_CAUSES` to `data_keys.AFFECTED_UNMODELED_CAUSES`

### Verification and Testing
Ran model and verified that new observer counts births, low-weight births, and total birth weight.