### PR TITLE
Feature/lbwsg mortality

### DIFF
--- a/src/vivarium_ciff_sam/components/__init__.py
+++ b/src/vivarium_ciff_sam/components/__init__.py
@@ -1,8 +1,8 @@
 from vivarium_ciff_sam.components.intervention import SQLNSIntervention, WastingTreatmentIntervention
+from vivarium_ciff_sam.components.mortality import Mortality
 from vivarium_ciff_sam.components.observers import (BirthObserver, CategoricalRiskObserver, DisabilityObserver,
                                                     DiseaseObserver, MortalityObserver)
-from vivarium_ciff_sam.components.lbwsg import (AffectedUnmodeledCause, LBWSGRisk, LBWSGRiskEffect, LBWSGSubRisk,
-                                                LowBirthWeight, ShortGestation)
+from vivarium_ciff_sam.components.lbwsg import LBWSGRisk, LBWSGRiskEffect, LBWSGSubRisk, LowBirthWeight, ShortGestation
 from vivarium_ciff_sam.components.treatment import SQLNSTreatment, WastingTreatment
 from vivarium_ciff_sam.components.wasting import ChildWasting
 from vivarium_ciff_sam.components.x_factor import XFactorExposure, XFactorEffect

--- a/src/vivarium_ciff_sam/components/lbwsg.py
+++ b/src/vivarium_ciff_sam/components/lbwsg.py
@@ -177,8 +177,7 @@ class LBWSGRiskEffect(RiskEffect):
         )
 
     def _get_population_attributable_fraction_source(self, builder: Builder) -> LookupTable:
-        paf_data = data_transformations.get_population_attributable_fraction_data(builder, self.risk,
-                                                                                  data_keys.DIARRHEA.EMR)
+        paf_data = builder.data.load(f'{self.risk}.population_attributable_fraction')
         return builder.lookup.build_table(paf_data, key_columns=['sex'], parameter_columns=['age', 'year'])
 
     def _get_target_modifier(self, builder: Builder) -> Callable[[pd.Index, pd.Series], pd.Series]:
@@ -214,10 +213,7 @@ class LBWSGRiskEffect(RiskEffect):
     # noinspection PyMethodMayBeStatic
     def _get_interpolator(self, builder: Builder) -> pd.Series:
         # get relative risk data for target
-        # todo remove effected entity/measure columns from artifact
-        interpolators = builder.data.load(data_keys.LBWSG.RELATIVE_RISK_INTERPOLATOR,
-                                          affected_entity=data_keys.DIARRHEA.name,
-                                          affected_measure='excess_mortality_rate')
+        interpolators = builder.data.load(data_keys.LBWSG.RELATIVE_RISK_INTERPOLATOR)
         interpolators = (
             # isolate RRs for target and drop non-neonatal age groups since they have RR == 1.0
             interpolators[interpolators['age_end'] < 0.5]

--- a/src/vivarium_ciff_sam/components/mortality.py
+++ b/src/vivarium_ciff_sam/components/mortality.py
@@ -1,0 +1,144 @@
+"""
+========================
+The Core Mortality Model
+========================
+Summary
+=======
+The mortality component models all cause mortality and allows for disease
+models to contribute cause specific mortality. At each timestep the
+currently "alive" population is subjected to a mortality event that uses
+the mortality hazard data to reap simulants. A weighted probable cause of
+death is used to pick a cause of death. The years of life lost are calculated
+by subtracting the simulant's age from the population TMRLE and the population
+is updated.
+Pipelines Exposed
+=================
+ - cause_specific_mortality_rate
+ - mortality_rate
+ - all_causes.mortality_hazard
+All cause mortality is read from the artifact (GBD). At setup cause specific
+mortality is initialized to an empty table. As disease models are incorporated
+they register as affecting cause specific mortality and their contributions
+are reflected in the cause_specific_mortality_rate pipeline. This is population
+level data.
+The mortality component's mortality_rate pipeline reflects the
+cause deleted mortality rate (ACMR - CSMR).
+Finally, the mortality component exposes a mortality hazard pipeline and a
+mortality hazard PAF pipeline (used internally). The cause specific rates are
+summed and added to the cause deleted mortality rate. These values are multiplied
+by 1 - PAF. The end product comprises the values in the mortality hazard pipeline.
+"""
+import pandas as pd
+
+from vivarium.framework.engine import Builder
+from vivarium.framework.event import Event
+from vivarium.framework.lookup import LookupTable
+from vivarium.framework.values import Pipeline, union_post_processor, list_combiner
+from vivarium_public_health.population import Mortality as _Mortality
+
+from vivarium_ciff_sam.constants import data_keys
+
+
+class Mortality(_Mortality):
+
+    def __init__(self):
+        super().__init__()
+        self.unmodeled_csmr_pipeline_name = 'affected_unmodeled.cause_specific_mortality_rate'
+        self.unmodeled_csmr_paf_pipeline_name = f'{self.unmodeled_csmr_pipeline_name}.paf'
+        self.all_cause_mortality_hazard_pipeline_name = 'all_causes.mortality_hazard'
+        self.all_cause_mortality_hazard_paf_pipeline_name = f'{self.all_cause_mortality_hazard_pipeline_name}.paf'
+
+    #################
+    # Setup methods #
+    #################
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder):
+        super().setup(builder)
+        self._raw_unmodeled_csmr = self._get_raw_unmodeled_csmr(builder)
+        self.unmodeled_csmr = self._get_unmodeled_csmr(builder)
+        self.unmodeled_csmr_paf = self._get_unmodeled_csmr_paf(builder)
+        self.mortality_hazard = self._get_mortality_hazard(builder)
+        self._mortality_hazard_paf = self._get_mortality_hazard_paf(builder)
+
+    # noinspection PyMethodMayBeStatic
+    def _get_raw_unmodeled_csmr(self, builder: Builder) -> LookupTable:
+        raw_csmr = pd.DataFrame()
+        for idx, cause in enumerate(data_keys.AFFECTED_UNMODELED_CAUSES):
+            if 0 == idx:
+                raw_csmr = builder.data.load(cause)
+            else:
+                raw_csmr.loc[:, 'value'] += builder.data.load(cause).value
+
+        return builder.lookup.build_table(raw_csmr, key_columns=['sex'], parameter_columns=['age', 'year'])
+
+    def _get_unmodeled_csmr(self, builder: Builder) -> Pipeline:
+        return builder.value.register_value_producer(
+            self.unmodeled_csmr_pipeline_name,
+            source=self._get_unmodeled_csmr_source,
+            requires_columns=['age', 'sex']
+        )
+
+    def _get_unmodeled_csmr_paf(self, builder: Builder) -> Pipeline:
+        unmodeled_csmr_paf = builder.lookup.build_table(0)
+        return builder.value.register_value_producer(
+            self.unmodeled_csmr_paf_pipeline_name,
+            source=lambda index: [unmodeled_csmr_paf(index)],
+            preferred_combiner=list_combiner,
+            preferred_post_processor=union_post_processor
+        )
+
+    def _get_mortality_hazard(self, builder: Builder) -> Pipeline:
+        return builder.value.register_value_producer(
+            self.all_cause_mortality_hazard_pipeline_name,
+            source=self._get_mortality_hazard_source
+        )
+
+    def _get_mortality_hazard_paf(self, builder: Builder) -> Pipeline:
+        return builder.value.register_value_producer(
+            self.all_cause_mortality_hazard_paf_pipeline_name,
+            source=lambda index: [pd.Series(0, index=index)],
+            preferred_combiner=list_combiner,
+            preferred_post_processor=union_post_processor,
+        )
+
+    ########################
+    # Event-driven methods #
+    ########################
+
+    def on_time_step(self, event: Event) -> None:
+        pop = self.population_view.get(event.index, query="alive =='alive'")
+        mortality_hazard = self.mortality_hazard(pop.index)
+        deaths = self.random.filter_for_rate(pop.index, mortality_hazard, additional_key='death')
+        if not deaths.empty:
+            cause_of_death_weights = self.mortality_rate(deaths).divide(mortality_hazard.loc[deaths], axis=0)
+            cause_of_death = self.random.choice(deaths, cause_of_death_weights.columns, cause_of_death_weights,
+                                                additional_key='cause_of_death')
+            pop.loc[deaths, 'alive'] = 'dead'
+            pop.loc[deaths, 'exit_time'] = event.time
+            pop.loc[deaths, 'years_of_life_lost'] = self.life_expectancy(deaths)
+            pop.loc[deaths, 'cause_of_death'] = cause_of_death
+            self.population_view.update(pop)
+
+    ##################################
+    # Pipeline sources and modifiers #
+    ##################################
+
+    def _calculate_mortality_rate(self, index: pd.Index) -> pd.DataFrame:
+        acmr = self.all_cause_mortality_rate(index)
+        modeled_csmr = self.cause_specific_mortality_rate(index)
+        unmodeled_csmr_raw = self._raw_unmodeled_csmr(index)
+        unmodeled_csmr = self.unmodeled_csmr(index)
+        cause_deleted_mortality_rate = acmr - modeled_csmr - unmodeled_csmr_raw + unmodeled_csmr
+        return pd.DataFrame({'other_causes': cause_deleted_mortality_rate})
+
+    def _get_unmodeled_csmr_source(self, index: pd.Index) -> pd.Series:
+        raw_csmr = self._raw_unmodeled_csmr(index)
+        paf = self.unmodeled_csmr_paf(index)
+        return raw_csmr * (1 - paf)
+
+    def _get_mortality_hazard_source(self, index: pd.Index) -> pd.Series:
+        mortality_rates = pd.DataFrame(self.mortality_rate(index))
+        mortality_hazard = mortality_rates.sum(axis=1)
+        paf = self._mortality_hazard_paf(index)
+        return mortality_hazard * (1 - paf)

--- a/src/vivarium_ciff_sam/components/observers.py
+++ b/src/vivarium_ciff_sam/components/observers.py
@@ -469,6 +469,8 @@ class BirthObserver:
                 measure_data = self.stratifier.update_labels(measure_data, labels)
                 metrics.update(measure_data)
 
+        return metrics
+
     def _get_births(self, pop: pd.DataFrame, base_filter: QueryString, configuration: Dict,
                     time_spans: List[Tuple[str, Tuple[pd.Timestamp, pd.Timestamp]]], age_bins: pd.DataFrame,
                     cutoff_weight: float = None) -> Dict[str, float]:

--- a/src/vivarium_ciff_sam/components/observers.py
+++ b/src/vivarium_ciff_sam/components/observers.py
@@ -201,9 +201,6 @@ class MortalityObserver(MortalityObserver_):
     def metrics(self, index: pd.Index, metrics: Dict[str, float]) -> Dict[str, float]:
         pop = self.population_view.get(index)
         pop.loc[pop.exit_time.isnull(), 'exit_time'] = self.clock()
-        pop.loc[
-            pop['cause_of_death'].isin(models.AFFECTED_UNMODELED_CAUSES), 'cause_of_death'
-        ] = data_keys.AFFECTED_UNMODELED_CAUSES.name
 
         measure_getters = (
             (utilities.get_deaths, (self.causes,)),

--- a/src/vivarium_ciff_sam/constants/data_keys.py
+++ b/src/vivarium_ciff_sam/constants/data_keys.py
@@ -294,17 +294,6 @@ class __AffectedUnmodeledCauses(NamedTuple):
     OTHER_NEONATAL_DISORDERS_CSMR: TargetString = TargetString('cause.other_neonatal_disorders.cause_specific_mortality_rate')
     SIDS_CSMR: TargetString = TargetString('cause.sudden_infant_death_syndrome.cause_specific_mortality_rate')
 
-    URI_RESTRICTIONS: TargetString = TargetString('cause.upper_respiratory_infections.restrictions')
-    OTITIS_MEDIA_RESTRICTIONS: TargetString = TargetString('cause.otitis_media.restrictions')
-    MENINGITIS_RESTRICTIONS: TargetString = TargetString('cause.meningitis.restrictions')
-    ENCEPHALITIS_RESTRICTIONS: TargetString = TargetString('cause.encephalitis.restrictions')
-    NEONATAL_PRETERM_BIRTH_RESTRICTIONS: TargetString = TargetString('cause.neonatal_preterm_birth.restrictions')
-    NEONATAL_ENCEPHALOPATHY_RESTRICTIONS: TargetString = TargetString('cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.restrictions')
-    NEONATAL_SEPSIS_RESTRICTIONS: TargetString = TargetString('cause.neonatal_sepsis_and_other_neonatal_infections.restrictions')
-    NEONATAL_JAUNDICE_RESTRICTIONS: TargetString = TargetString('cause.hemolytic_disease_and_other_neonatal_jaundice.restrictions')
-    OTHER_NEONATAL_DISORDERS_RESTRICTIONS: TargetString = TargetString('cause.other_neonatal_disorders.restrictions')
-    SIDS_RESTRICTIONS: TargetString = TargetString('cause.sudden_infant_death_syndrome.restrictions')
-
     # Useful keys not for the artifact - distinguished by not using the colon type declaration
 
     @property

--- a/src/vivarium_ciff_sam/constants/results.py
+++ b/src/vivarium_ciff_sam/constants/results.py
@@ -1,6 +1,6 @@
 import itertools
 
-from vivarium_ciff_sam.constants import data_keys, models
+from vivarium_ciff_sam.constants import models
 
 #################################
 # Results columns and variables #
@@ -64,7 +64,6 @@ CAUSES_OF_DEATH = (
     models.LRI.STATE_NAME,
     models.WASTING.MODERATE_STATE_NAME,
     models.WASTING.SEVERE_STATE_NAME,
-    data_keys.AFFECTED_UNMODELED_CAUSES.name
 )
 CAUSES_OF_DISABILITY = (
     models.DIARRHEA.STATE_NAME,

--- a/src/vivarium_ciff_sam/data/loader.py
+++ b/src/vivarium_ciff_sam/data/loader.py
@@ -13,7 +13,7 @@ for an example.
    No logging is done here. Logging is done in vivarium inputs itself and forwarded.
 """
 import pickle
-from typing import Dict, Tuple, Type
+from typing import Tuple, Type
 
 import numpy as np
 import pandas as pd
@@ -128,17 +128,6 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_JAUNDICE_CSMR: load_standard_data,
         data_keys.AFFECTED_UNMODELED_CAUSES.OTHER_NEONATAL_DISORDERS_CSMR: load_standard_data,
         data_keys.AFFECTED_UNMODELED_CAUSES.SIDS_CSMR: load_sids_csmr,
-
-        data_keys.AFFECTED_UNMODELED_CAUSES.URI_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.AFFECTED_UNMODELED_CAUSES.OTITIS_MEDIA_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.AFFECTED_UNMODELED_CAUSES.MENINGITIS_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.AFFECTED_UNMODELED_CAUSES.ENCEPHALITIS_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_PRETERM_BIRTH_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_ENCEPHALOPATHY_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_SEPSIS_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_JAUNDICE_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.AFFECTED_UNMODELED_CAUSES.OTHER_NEONATAL_DISORDERS_RESTRICTIONS: load_unmodeled_causes_restrictions,
-        data_keys.AFFECTED_UNMODELED_CAUSES.SIDS_RESTRICTIONS: load_unmodeled_causes_restrictions,
     }
     return mapping[lookup_key](lookup_key, location)
 
@@ -550,20 +539,3 @@ def load_sids_csmr(key: str, location: str) -> pd.DataFrame:
         return data
     else:
         raise ValueError(f'Unrecognized key {key}')
-
-
-# noinspection PyUnusedLocal
-def load_unmodeled_causes_restrictions(key: str, location: str) -> Dict:
-    if key not in data_keys.AFFECTED_UNMODELED_CAUSES or 'restrictions' not in key:
-        raise ValueError(f'Unrecognized key {key}')
-
-    return {
-        'male_only': False,
-        'female_only': False,
-        'yll_only': False,
-        'yld_only': False,
-        'yll_age_group_id_start': 2,
-        'yll_age_group_id_end': 235,
-        'yld_age_group_id_start': 2,
-        'yld_age_group_id_end': 235
-    }

--- a/src/vivarium_ciff_sam/data/loader.py
+++ b/src/vivarium_ciff_sam/data/loader.py
@@ -437,7 +437,11 @@ def load_lbwsg_rr(key: str, location: str) -> pd.DataFrame:
     data = data[data['year_id'] == 2019].drop(columns='year_id')
     data = utilities.process_relative_risk(data, key, entity, location, metadata.GBD_2019_ROUND_ID,
                                            metadata.AGE_GROUP.GBD_2020, whitelist_sids=True)
-    data = data[data.index.get_level_values('year_start') == 2019]
+    data = (
+        data.query('year_start == 2019')
+        .droplevel(['affected_entity', 'affected_measure'])
+    )
+    data = data[~data.index.duplicated()]
     return data
 
 
@@ -449,7 +453,7 @@ def load_lbwsg_interpolated_rr(key: str, location: str) -> pd.DataFrame:
     rr['parameter'] = pd.Categorical(rr['parameter'], [f'cat{i}' for i in range(1000)])
     rr = (
         rr.sort_values('parameter')
-        .set_index(metadata.ARTIFACT_INDEX_COLUMNS + ['affected_entity', 'affected_measure', 'parameter'])
+        .set_index(metadata.ARTIFACT_INDEX_COLUMNS + ['parameter'])
         .stack()
         .unstack('parameter')
         .apply(np.log)

--- a/src/vivarium_ciff_sam/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/branches/scenarios.yaml
@@ -1,5 +1,5 @@
 input_draw_count: 12
-random_seed_count: 10
+random_seed_count: 100
 
 branches:
   - intervention:

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -79,7 +79,7 @@ configuration:
             day: 31
         step_size: 0.5 # Days
     population:
-        population_size: 10_000
+        population_size: 1_000
         age_start: 0
         age_end: 5
         exit_age: 5

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -2,7 +2,6 @@ components:
     vivarium_public_health:
         population:
             - BasePopulation()
-            - Mortality()
             - FertilityCrudeBirthRate()
         disease:
             - SIS('diarrheal_diseases')
@@ -25,34 +24,16 @@ components:
 
     vivarium_ciff_sam:
         components:
-            - ChildWasting()
+            - Mortality()
 
-            - AffectedUnmodeledCause('upper_respiratory_infections')
-            - AffectedUnmodeledCause('otitis_media')
-            - AffectedUnmodeledCause('meningitis')
-            - AffectedUnmodeledCause('encephalitis')
-            - AffectedUnmodeledCause('neonatal_preterm_birth')
-            - AffectedUnmodeledCause('neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma')
-            - AffectedUnmodeledCause('neonatal_sepsis_and_other_neonatal_infections')
-            - AffectedUnmodeledCause('hemolytic_disease_and_other_neonatal_jaundice')
-            - AffectedUnmodeledCause('other_neonatal_disorders')
-            - AffectedUnmodeledCause('sudden_infant_death_syndrome')
+            - ChildWasting()
 
             - LBWSGRisk()
             - LowBirthWeight()
             - ShortGestation()
             - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
             - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.upper_respiratory_infections.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.otitis_media.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.meningitis.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.encephalitis.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.neonatal_preterm_birth.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.neonatal_sepsis_and_other_neonatal_infections.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.hemolytic_disease_and_other_neonatal_jaundice.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.other_neonatal_disorders.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.sudden_infant_death_syndrome.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
 
             - XFactorExposure()
             - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -3,58 +3,58 @@ components:
         population:
             - BasePopulation()
             - FertilityCrudeBirthRate()
-        disease:
-            - SIS('diarrheal_diseases')
-            - SIS_fixed_duration('measles', '10.0')
-            - SIS('lower_respiratory_infections')
-        risks:
-            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
-            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
-            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
-
-            - Risk('risk_factor.child_stunting')
-            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
-            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
-            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
-
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
-
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
+#        disease:
+#            - SIS('diarrheal_diseases')
+#            - SIS_fixed_duration('measles', '10.0')
+#            - SIS('lower_respiratory_infections')
+#        risks:
+#            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
+#            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
+#            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
+#
+#            - Risk('risk_factor.child_stunting')
+#            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
+#            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
+#            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
+#
+#            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
+#            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
+#
+#            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
 
     vivarium_ciff_sam:
         components:
             - Mortality()
 
-            - ChildWasting()
+#            - ChildWasting()
 
             - LBWSGRisk()
             - LowBirthWeight()
             - ShortGestation()
-            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
 
-            - XFactorExposure()
-            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
-            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
-
-            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
-            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
-            - SQLNSTreatment()
-
-            - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
-            - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')
-            - SQLNSIntervention()
-
-            - DisabilityObserver('wasting')
-            - MortalityObserver('wasting')
-            - DiseaseObserver('diarrheal_diseases', 'wasting')
-            - DiseaseObserver('measles', 'wasting')
-            - DiseaseObserver('lower_respiratory_infections', 'wasting')
-            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
-            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
-            - BirthObserver()
+#            - XFactorExposure()
+#            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
+#            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
+#
+#            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
+#            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
+#            - SQLNSTreatment()
+#
+#            - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
+#            - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')
+#            - SQLNSIntervention()
+#
+#            - DisabilityObserver('wasting')
+#            - MortalityObserver('wasting')
+#            - DiseaseObserver('diarrheal_diseases', 'wasting')
+#            - DiseaseObserver('measles', 'wasting')
+#            - DiseaseObserver('lower_respiratory_infections', 'wasting')
+#            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
+#            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
+#            - BirthObserver()
 
 configuration:
     input_data:

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -3,58 +3,58 @@ components:
         population:
             - BasePopulation()
             - FertilityCrudeBirthRate()
-#        disease:
-#            - SIS('diarrheal_diseases')
-#            - SIS_fixed_duration('measles', '10.0')
-#            - SIS('lower_respiratory_infections')
-#        risks:
-#            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
-#            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
-#            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
-#
-#            - Risk('risk_factor.child_stunting')
-#            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
-#            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
-#            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
-#
-#            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
-#            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
-#
-#            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
+        disease:
+            - SIS('diarrheal_diseases')
+            - SIS_fixed_duration('measles', '10.0')
+            - SIS('lower_respiratory_infections')
+        risks:
+            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
+            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
+            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
+
+            - Risk('risk_factor.child_stunting')
+            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
+            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
+            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
+
+            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
+
+            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
 
     vivarium_ciff_sam:
         components:
             - Mortality()
 
-#            - ChildWasting()
+            - ChildWasting()
 
             - LBWSGRisk()
             - LowBirthWeight()
             - ShortGestation()
-#            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
 
-#            - XFactorExposure()
-#            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
-#            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
-#
-#            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
-#            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
-#            - SQLNSTreatment()
-#
-#            - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
-#            - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')
-#            - SQLNSIntervention()
-#
-#            - DisabilityObserver('wasting')
-#            - MortalityObserver('wasting')
-#            - DiseaseObserver('diarrheal_diseases', 'wasting')
-#            - DiseaseObserver('measles', 'wasting')
-#            - DiseaseObserver('lower_respiratory_infections', 'wasting')
-#            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
-#            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
-#            - BirthObserver()
+            - XFactorExposure()
+            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
+            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
+
+            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
+            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
+            - SQLNSTreatment()
+
+            - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
+            - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')
+            - SQLNSIntervention()
+
+            - DisabilityObserver('wasting')
+            - MortalityObserver('wasting')
+            - DiseaseObserver('diarrheal_diseases', 'wasting')
+            - DiseaseObserver('measles', 'wasting')
+            - DiseaseObserver('lower_respiratory_infections', 'wasting')
+            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
+            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
+            - BirthObserver()
 
 configuration:
     input_data:


### PR DESCRIPTION
## Implement LBWSG affect on unmodeled causes
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix,
- *JIRA issue*: [MIC-2791](https://jira.ihme.washington.edu/browse/MIC-2791)
- *Research reference*: [LBWSG risk effects](https://vivarium-research.readthedocs.io/en/latest/gbd2017_models/risk_exposure/low_birthweight_short_gestation/index.html)

Removes effects of LBWSG on individual unmodeled causes and utilizes the Mortality component code from LSFF
Drop redundant rows from LBWSG risk effect, interpolator, and paf tables.

### Verification and Testing
Rebuilt artifact
Used interactive sim to verify mortality pipelines are appropriately affected.