### PR TITLE
Feature/maternal bmi

### DIFF
--- a/src/vivarium_ciff_sam/components/__init__.py
+++ b/src/vivarium_ciff_sam/components/__init__.py
@@ -3,6 +3,7 @@ from vivarium_ciff_sam.components.mortality import Mortality
 from vivarium_ciff_sam.components.observers import (BirthObserver, CategoricalRiskObserver, DisabilityObserver,
                                                     DiseaseObserver, MortalityObserver)
 from vivarium_ciff_sam.components.lbwsg import LBWSGRisk, LBWSGRiskEffect, LBWSGSubRisk, LowBirthWeight, ShortGestation
+from vivarium_ciff_sam.components.maternal_malnutrition import AdditiveRiskEffect
 from vivarium_ciff_sam.components.treatment import SQLNSTreatment, WastingTreatment
 from vivarium_ciff_sam.components.wasting import ChildWasting
 from vivarium_ciff_sam.components.x_factor import XFactorExposure, XFactorEffect

--- a/src/vivarium_ciff_sam/components/maternal_malnutrition.py
+++ b/src/vivarium_ciff_sam/components/maternal_malnutrition.py
@@ -1,0 +1,69 @@
+from typing import Callable
+
+import pandas as pd
+
+from vivarium.framework.engine import Builder
+from vivarium.framework.lookup import LookupTable
+from vivarium_public_health.risks import RiskEffect
+
+from vivarium_ciff_sam.constants import data_keys
+
+
+class AdditiveRiskEffect(RiskEffect):
+
+    def __init__(self, risk: str, target: str):
+        super().__init__(risk, target)
+        self.target_risk_specific_shift_pipeline_name = f'{self.target.name}.risk_specific_shift'
+
+    def setup(self, builder: Builder) -> None:
+        super().setup(builder)
+        self._register_risk_specific_shift_modifier(builder)
+
+    def _get_target_modifier(self, builder: Builder) -> Callable[[pd.Index, pd.Series], pd.Series]:
+        risk_exposure = builder.value.get_value(f'{self.risk.name}.exposure')
+
+        def exposure_effect(target, rr: pd.DataFrame) -> pd.Series:
+            index_columns = ['index', self.risk.name]
+
+            exposure = risk_exposure(rr.index).reset_index()
+            exposure.columns = index_columns
+            exposure = exposure.set_index(index_columns)
+
+            relative_risk = rr.stack().reset_index()
+            relative_risk.columns = index_columns + ['value']
+            relative_risk = relative_risk.set_index(index_columns)
+
+            effect = relative_risk.loc[exposure.index, 'value'].droplevel(self.risk.name)
+            affected_rates = target + effect
+            return affected_rates
+
+        def adjust_target(index: pd.Index, target: pd.Series) -> pd.Series:
+            return exposure_effect(target, self.relative_risk(index))
+
+        return adjust_target
+
+    def _risk_specific_shift_source(self, builder: Builder) -> LookupTable:
+        risk_specific_shift_data = builder.data.load(
+            data_keys.MATERNAL_MALNUTRITION.RISK_SPECIFIC_SHIFT,
+            affected_entity=self.target.name,
+            affected_measure=self.target.measure
+        )
+        return builder.lookup.build_table(
+            risk_specific_shift_data,
+            key_columns=['sex'],
+            parameter_columns=['age', 'year']
+        )
+
+    def _register_paf_modifier(self, builder: Builder) -> None:
+        pass
+
+    def _register_risk_specific_shift_modifier(self, builder: Builder) -> None:
+        builder.value.register_value_modifier(
+            self.target_risk_specific_shift_pipeline_name,
+            modifier=self._risk_specific_shift_source,
+            requires_columns=['age', 'sex']
+        )
+
+    ##################################
+    # Pipeline sources and modifiers #
+    ##################################

--- a/src/vivarium_ciff_sam/data/utilities.py
+++ b/src/vivarium_ciff_sam/data/utilities.py
@@ -429,7 +429,8 @@ def filter_relative_risk_to_cause_restrictions(data: pd.DataFrame) -> pd.DataFra
     return data
 
 
-def get_dichotomous_draws_from_distribution(key: TargetString, index: pd.Index, distribution: Tuple) -> pd.DataFrame:
+def get_dichotomous_draws_from_distribution(key: str, index: pd.Index, distribution: Tuple) -> pd.DataFrame:
+    key = TargetString(key)
 
     data = get_random_variable_draws(pd.Index([f'draw_{i}' for i in range(0, 1000)]), *distribution)
 

--- a/src/vivarium_ciff_sam/data/utilities.py
+++ b/src/vivarium_ciff_sam/data/utilities.py
@@ -13,7 +13,6 @@ from vivarium_gbd_access.utilities import get_draws, query
 from vivarium_inputs import globals as vi_globals, utilities as vi_utils, utility_data
 from vivarium_inputs.mapping_extension import alternative_risk_factors, AlternativeRiskFactor
 from vivarium_inputs.validation.raw import check_metadata
-from vivarium_public_health.utilities import TargetString
 
 from vivarium_ciff_sam.constants import data_keys, data_values
 from vivarium_ciff_sam.constants.metadata import ARTIFACT_INDEX_COLUMNS, AGE_GROUP, GBD_2020_ROUND_ID
@@ -426,20 +425,4 @@ def filter_relative_risk_to_cause_restrictions(data: pd.DataFrame) -> pd.DataFra
             start, end = vi_utils.get_age_group_ids_by_restriction(cause, 'yld')
         temp.append(df[df.age_group_id.isin(range(start, end + 1))])
     data = pd.concat(temp)
-    return data
-
-
-def get_dichotomous_draws_from_distribution(key: str, index: pd.Index, distribution: Tuple) -> pd.DataFrame:
-    key = TargetString(key)
-
-    data = get_random_variable_draws(pd.Index([f'draw_{i}' for i in range(0, 1000)]), *distribution)
-
-    cat2 = pd.DataFrame({f'draw_{i}': 1.0 for i in range(0, 1000)}, index=index) * data
-    cat1 = 1 - cat2
-
-    if key.type == 'risk_factor':
-        cat1['parameter'] = 'cat1'
-        cat2['parameter'] = 'cat2'
-
-    data = pd.concat([cat1, cat2]).set_index('parameter', append=True).sort_index()
     return data

--- a/src/vivarium_ciff_sam/data/utilities.py
+++ b/src/vivarium_ciff_sam/data/utilities.py
@@ -13,6 +13,7 @@ from vivarium_gbd_access.utilities import get_draws, query
 from vivarium_inputs import globals as vi_globals, utilities as vi_utils, utility_data
 from vivarium_inputs.mapping_extension import alternative_risk_factors, AlternativeRiskFactor
 from vivarium_inputs.validation.raw import check_metadata
+from vivarium_public_health.utilities import TargetString
 
 from vivarium_ciff_sam.constants import data_keys, data_values
 from vivarium_ciff_sam.constants.metadata import ARTIFACT_INDEX_COLUMNS, AGE_GROUP, GBD_2020_ROUND_ID
@@ -425,4 +426,19 @@ def filter_relative_risk_to_cause_restrictions(data: pd.DataFrame) -> pd.DataFra
             start, end = vi_utils.get_age_group_ids_by_restriction(cause, 'yld')
         temp.append(df[df.age_group_id.isin(range(start, end + 1))])
     data = pd.concat(temp)
+    return data
+
+
+def get_dichotomous_draws_from_distribution(key: TargetString, index: pd.Index, distribution: Tuple) -> pd.DataFrame:
+
+    data = get_random_variable_draws(pd.Index([f'draw_{i}' for i in range(0, 1000)]), *distribution)
+
+    cat2 = pd.DataFrame({f'draw_{i}': 1.0 for i in range(0, 1000)}, index=index) * data
+    cat1 = 1 - cat2
+
+    if key.type == 'risk_factor':
+        cat1['parameter'] = 'cat1'
+        cat2['parameter'] = 'cat2'
+
+    data = pd.concat([cat1, cat2]).set_index('parameter', append=True).sort_index()
     return data

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -12,10 +12,7 @@ components:
             - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
             - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
 
-            - Risk('risk_factor.child_stunting')
-            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
-            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
-            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
+            - Risk('risk_factor.maternal_malnutrition')
 
             - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
             - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
@@ -35,13 +32,11 @@ components:
             - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
 
+            - AdditiveRiskEffect('risk_factor.maternal_malnutrition', 'risk_factor.low_birth_weight.exposure')
+
             - XFactorExposure()
             - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
             - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
-
-            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
-            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
-            - SQLNSTreatment()
 
             - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
             - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -37,7 +37,7 @@ components:
 #            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
 #            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
 
-#            - AdditiveRiskEffect('risk_factor.maternal_malnutrition', 'risk_factor.low_birth_weight.exposure')
+            - AdditiveRiskEffect('risk_factor.maternal_malnutrition', 'risk_factor.low_birth_weight.exposure')
 
 #            - XFactorExposure()
 #            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -3,8 +3,8 @@ components:
         population:
             - BasePopulation()
             - FertilityCrudeBirthRate()
-#        disease:
-#            - SIS('diarrheal_diseases')
+        disease:
+            - SIS('diarrheal_diseases')
 #            - SIS_fixed_duration('measles', '10.0')
 #            - SIS('lower_respiratory_infections')
         risks:
@@ -33,11 +33,11 @@ components:
             - LBWSGRisk()
             - LowBirthWeight()
             - ShortGestation()
-#            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
 #            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
 #            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
 
-            - AdditiveRiskEffect('risk_factor.maternal_malnutrition', 'risk_factor.low_birth_weight.exposure')
+#            - AdditiveRiskEffect('risk_factor.maternal_malnutrition', 'risk_factor.low_birth_weight.exposure')
 
 #            - XFactorExposure()
 #            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -3,53 +3,62 @@ components:
         population:
             - BasePopulation()
             - FertilityCrudeBirthRate()
-        disease:
-            - SIS('diarrheal_diseases')
-            - SIS_fixed_duration('measles', '10.0')
-            - SIS('lower_respiratory_infections')
+#        disease:
+#            - SIS('diarrheal_diseases')
+#            - SIS_fixed_duration('measles', '10.0')
+#            - SIS('lower_respiratory_infections')
         risks:
-            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
-            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
-            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
+#            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
+#            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
+#            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
+#
+#            - Risk('risk_factor.child_stunting')
+#            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
+#            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
+#            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
 
             - Risk('risk_factor.maternal_malnutrition')
 
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
-            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
-
-            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
+#            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
+#            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
+#
+#            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
 
     vivarium_ciff_sam:
         components:
             - Mortality()
 
-            - ChildWasting()
+#            - ChildWasting()
 
             - LBWSGRisk()
             - LowBirthWeight()
             - ShortGestation()
-            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
-            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
+#            - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
+#            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
 
             - AdditiveRiskEffect('risk_factor.maternal_malnutrition', 'risk_factor.low_birth_weight.exposure')
 
-            - XFactorExposure()
-            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
-            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
-
-            - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
-            - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')
-            - SQLNSIntervention()
-
-            - DisabilityObserver('wasting')
-            - MortalityObserver('wasting')
-            - DiseaseObserver('diarrheal_diseases', 'wasting')
-            - DiseaseObserver('measles', 'wasting')
-            - DiseaseObserver('lower_respiratory_infections', 'wasting')
-            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
-            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
-            - BirthObserver()
+#            - XFactorExposure()
+#            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
+#            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
+#
+#            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
+#            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
+#            - SQLNSTreatment()
+#
+#            - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
+#            - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')
+#            - SQLNSIntervention()
+#
+#            - DisabilityObserver('wasting')
+#            - MortalityObserver('wasting')
+#            - DiseaseObserver('diarrheal_diseases', 'wasting')
+#            - DiseaseObserver('measles', 'wasting')
+#            - DiseaseObserver('lower_respiratory_infections', 'wasting')
+#            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
+#            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
+#            - BirthObserver()
 
 configuration:
     input_data:

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -5,60 +5,60 @@ components:
             - FertilityCrudeBirthRate()
         disease:
             - SIS('diarrheal_diseases')
-#            - SIS_fixed_duration('measles', '10.0')
-#            - SIS('lower_respiratory_infections')
+            - SIS_fixed_duration('measles', '10.0')
+            - SIS('lower_respiratory_infections')
         risks:
-#            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
-#            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
-#            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
-#
-#            - Risk('risk_factor.child_stunting')
-#            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
-#            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
-#            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
+            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
+            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
+            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
+
+            - Risk('risk_factor.child_stunting')
+            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
+            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
+            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
 
             - Risk('risk_factor.maternal_malnutrition')
 
-#            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
-#            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
-#
-#            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
+            - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
+
+            - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
 
     vivarium_ciff_sam:
         components:
             - Mortality()
 
-#            - ChildWasting()
+            - ChildWasting()
 
             - LBWSGRisk()
             - LowBirthWeight()
             - ShortGestation()
             - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
-#            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
+            - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
+            - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
 
             - AdditiveRiskEffect('risk_factor.maternal_malnutrition', 'risk_factor.low_birth_weight.exposure')
 
-#            - XFactorExposure()
-#            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
-#            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
-#
-#            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
-#            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
-#            - SQLNSTreatment()
-#
-#            - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
-#            - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')
-#            - SQLNSIntervention()
-#
-#            - DisabilityObserver('wasting')
-#            - MortalityObserver('wasting')
-#            - DiseaseObserver('diarrheal_diseases', 'wasting')
-#            - DiseaseObserver('measles', 'wasting')
-#            - DiseaseObserver('lower_respiratory_infections', 'wasting')
-#            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
-#            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
-#            - BirthObserver()
+            - XFactorExposure()
+            - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
+            - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
+
+            - WastingTreatment('risk_factor.severe_acute_malnutrition_treatment')
+            - WastingTreatment('risk_factor.moderate_acute_malnutrition_treatment')
+            - SQLNSTreatment()
+
+            - WastingTreatmentIntervention('risk_factor.severe_acute_malnutrition_treatment')
+            - WastingTreatmentIntervention('risk_factor.moderate_acute_malnutrition_treatment')
+            - SQLNSIntervention()
+
+            - DisabilityObserver('wasting')
+            - MortalityObserver('wasting')
+            - DiseaseObserver('diarrheal_diseases', 'wasting')
+            - DiseaseObserver('measles', 'wasting')
+            - DiseaseObserver('lower_respiratory_infections', 'wasting')
+            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
+            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
+            - BirthObserver()
 
 configuration:
     input_data:


### PR DESCRIPTION
## Implement Maternal malnutrition risk
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: implementation
- *JIRA issue*: [MIC-2794](https://jira.ihme.washington.edu/browse/MIC-2794)
- *Research reference*: [Exposure](https://vivarium-research.readthedocs.io/en/latest/gbd2019_models/risk_exposures/maternal_bmi/index.html#id2) - [Effect](https://vivarium-research.readthedocs.io/en/latest/gbd2019_models/risk_risk_correlation/maternal_bmi_birthweight/index.html#vivarium-modeling-strategy)

Add a new pipeline to the LBWSG to replace the paf pipeline in creating a risk-deleted exposure.
Created a new AdditiveRiskEffect component.
The target effect is just copying the code from vph, except that it add to the target rather than multiplying to it.
In place a of a paf is has a "risk specific shift" to get the difference between TMREL and the true exposure.

### Verification and Testing
Ran in an interactive sim to verify that exposed has a lower birthweight than tmrel that roughly corresponds to the expected value.