### PR TITLE
Bugfix/birth columns

### DIFF
--- a/src/vivarium_ciff_sam/components/lbwsg.py
+++ b/src/vivarium_ciff_sam/components/lbwsg.py
@@ -110,7 +110,7 @@ class LBWSGSubRisk(Risk, ABC):
     ##################################
 
     def _get_current_exposure(self, index: pd.Index) -> pd.Series:
-        exposure = self.population_view.get(index)[[self.exposure_column_name]]
+        exposure = self.population_view.get(index)[self.exposure_column_name]
         return exposure
 
     def _get_birth_exposure(self, index: pd.Index) -> pd.Series:

--- a/src/vivarium_ciff_sam/constants/data_keys.py
+++ b/src/vivarium_ciff_sam/constants/data_keys.py
@@ -265,7 +265,7 @@ class __LowBirthWeightShortGestation(NamedTuple):
     PAF: TargetString = 'risk_factor.low_birth_weight_and_short_gestation.population_attributable_fraction'
 
     # Useful keys not for the artifact - distinguished by not using the colon type declaration
-    BIRTH_WEIGHT_EXPOSURE = TargetString('risk_factor.low_birth_weight.exposure')
+    BIRTH_WEIGHT_EXPOSURE = TargetString('risk_factor.low_birth_weight.birth_exposure')
     TMREL_CATEGORIES = {'cat53', 'cat54', 'cat55', 'cat56'}
     TMREL_GESTATIONAL_AGE_INTERVAL = pd.Interval(38.0, 42.0)
     TMREL_BIRTH_WEIGHT_INTERVAL = pd.Interval(3500.0, 4500.0)

--- a/src/vivarium_ciff_sam/data/loader.py
+++ b/src/vivarium_ciff_sam/data/loader.py
@@ -679,7 +679,7 @@ def load_dichotomous_excess_shift(
         excess_shift
         .set_index(['affected_entity', 'affected_measure', 'parameter'], append=True)
         .sort_index()
-)
+    )
     return excess_shift
 
 

--- a/src/vivarium_ciff_sam/data/loader.py
+++ b/src/vivarium_ciff_sam/data/loader.py
@@ -679,7 +679,7 @@ def load_dichotomous_excess_shift(
         excess_shift
         .set_index(['affected_entity', 'affected_measure', 'parameter'], append=True)
         .sort_index()
-    )
+)
     return excess_shift
 
 

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -38,15 +38,15 @@ components:
             - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
 
             - RiskWithTracked('risk_factor.maternal_malnutrition')
-            - AdditiveRiskEffect('risk_factor.maternal_malnutrition', 'risk_factor.low_birth_weight.exposure')
+            - AdditiveRiskEffect('risk_factor.maternal_malnutrition', 'risk_factor.low_birth_weight.birth_exposure')
 
             - MaternalSupplementation()
             - MaternalSupplementationType('risk_factor.iron_folic_acid_supplementation')
             - MaternalSupplementationType('risk_factor.multiple_micronutrient_supplementation')
             - BEPSupplementation()
-            - AdditiveRiskEffect('risk_factor.iron_folic_acid_supplementation', 'risk_factor.low_birth_weight.exposure')
-            - AdditiveRiskEffect('risk_factor.multiple_micronutrient_supplementation', 'risk_factor.low_birth_weight.exposure')
-            - AdditiveRiskEffect('risk_factor.balanced_energy_protein_supplementation', 'risk_factor.low_birth_weight.exposure')
+            - AdditiveRiskEffect('risk_factor.iron_folic_acid_supplementation', 'risk_factor.low_birth_weight.birth_exposure')
+            - AdditiveRiskEffect('risk_factor.multiple_micronutrient_supplementation', 'risk_factor.low_birth_weight.birth_exposure')
+            - AdditiveRiskEffect('risk_factor.balanced_energy_protein_supplementation', 'risk_factor.low_birth_weight.birth_exposure')
             - MaternalSupplementationIntervention('risk_factor.iron_folic_acid_supplementation')
             - MaternalSupplementationIntervention('risk_factor.multiple_micronutrient_supplementation')
 

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -17,8 +17,6 @@ components:
             - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
             - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
 
-            - Risk('risk_factor.maternal_malnutrition')
-
             - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_mild_child_wasting.transition_rate')
             - RiskEffect('risk_factor.severe_acute_malnutrition_treatment', 'risk_factor.severe_acute_malnutrition_to_moderate_acute_malnutrition.transition_rate')
 


### PR DESCRIPTION
## Fix birth-weight exposure at birth
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-2827](https://jira.ihme.washington.edu/browse/MIC-2827)
- *Research reference*: N/A

Storing birth-weight and gestational age exposures in a column mediated by the new birth exposure pipeline. 
Getting exposure with a simple column lookup
Fix bug with duplicated maternal malnutrition components


### Verification and Testing
Tested in an interactive sim to verify exposure still looks the same and risk effects are still applied appropriately.