### PR TITLE
Allowing non-wasting column stratification

### DIFF
--- a/src/vivarium_ciff_sam/components/observers.py
+++ b/src/vivarium_ciff_sam/components/observers.py
@@ -76,7 +76,7 @@ class ResultsStratifier:
             if is_pipeline:
                 self.pipelines[source_name] = builder.value.get_value(source_name)
             else:
-                columns_required.append(data_keys.WASTING.name)
+                columns_required.append(source_name)
 
         if self.by_wasting:
             setup_stratification(data_keys.WASTING.name, False, 'wasting_state', models.WASTING.STATES)


### PR DESCRIPTION
## Allowing non-wasting column stratification
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
Changed behavior of `setup.setup_stratification` in `observers.py` to allow for any stratification component to use either column or pipeline
- *Category*: bugfix
- *JIRA issue*: [MIC-2883](https://jira.ihme.washington.edu/browse/MIC-2883)
- *Research reference*: NA

Changed "columns required" by `setup.setup_stratification` to be more general

### Verification and Testing
Checked that `sim.take_steps()` works at different points in the simulation for the baseline and lbwsg scenarios. **If there are other checks that you would recommend, please let me know! I think I probably should also be checking that I didn't break any sort of stratification behavior but I wasn't sure precisely what to be checking**