### PR TITLE
Observers/vicious cycle

### DIFF
--- a/src/vivarium_ciff_sam/components/__init__.py
+++ b/src/vivarium_ciff_sam/components/__init__.py
@@ -28,5 +28,5 @@ from vivarium_ciff_sam.components.risk import (
     RiskWithTracked
 )
 from vivarium_ciff_sam.components.treatment import SQLNSTreatment, WastingTreatment
-from vivarium_ciff_sam.components.wasting import ChildWasting
+from vivarium_ciff_sam.components.wasting import ChildWasting, DiarrheaRiskEffect
 from vivarium_ciff_sam.components.x_factor import XFactorExposure, XFactorEffect

--- a/src/vivarium_ciff_sam/components/observers.py
+++ b/src/vivarium_ciff_sam/components/observers.py
@@ -38,7 +38,8 @@ class ResultsStratifier:
             by_stunting: str = 'False',
             by_maternal_malnutrition: str = 'False',
             by_maternal_supplementation: str = 'False',
-            by_insecticide_treated_nets: str = 'False'
+            by_insecticide_treated_nets: str = 'False',
+            by_diarrhea: str = 'False'
     ):
         self.name = f'{observer_name}_results_stratifier'
         self.by_wasting = by_wasting != 'False'
@@ -49,6 +50,7 @@ class ResultsStratifier:
         self.by_maternal_malnutrition = by_maternal_malnutrition != 'False'
         self.by_maternal_supplementation = by_maternal_supplementation != 'False'
         self.by_insecticide_treated_nets = by_insecticide_treated_nets != 'False'
+        self.by_diarrhea = by_diarrhea != 'False'
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
@@ -128,6 +130,17 @@ class ResultsStratifier:
                 categories={
                     'covered': data_keys.INSECTICIDE_TX_NETS.CAT2,
                     'uncovered': data_keys.INSECTICIDE_TX_NETS.CAT1
+                }
+            )
+
+        if self.by_diarrhea:
+            setup_stratification(
+                source_name=data_keys.DIARRHEA.name,
+                is_pipeline=False,
+                stratification_name='diarrhea',
+                categories={
+                    'cat1': models.DIARRHEA.STATE_NAME,
+                    'cat2': models.DIARRHEA.SUSCEPTIBLE_STATE_NAME
                 }
             )
 
@@ -232,25 +245,9 @@ class ResultsStratifier:
 
 class MortalityObserver(MortalityObserver_):
 
-    def __init__(
-            self,
-            stratify_by_wasting: str = 'wasting',
-            stratify_by_sq_lns: str = 'False',
-            stratify_by_wasting_treatment: str = 'False',
-            stratify_by_x_factor: str = 'False',
-            stratify_by_stunting: str = 'False',
-            stratify_by_maternal_malnutrition: str = 'False'
-    ):
+    def __init__(self, stratify_by_wasting: str = 'wasting'):
         super().__init__()
-        self.stratifier = ResultsStratifier(
-            self.name,
-            stratify_by_wasting,
-            stratify_by_sq_lns,
-            stratify_by_wasting_treatment,
-            stratify_by_x_factor,
-            stratify_by_stunting,
-            stratify_by_maternal_malnutrition
-        )
+        self.stratifier = ResultsStratifier(self.name, by_wasting=stratify_by_wasting)
 
     @property
     def sub_components(self) -> List[ResultsStratifier]:
@@ -286,25 +283,9 @@ class MortalityObserver(MortalityObserver_):
 
 class DisabilityObserver(DisabilityObserver_):
 
-    def __init__(
-            self,
-            stratify_by_wasting: str = 'wasting',
-            stratify_by_sq_lns: str = 'False',
-            stratify_by_wasting_treatment: str = 'False',
-            stratify_by_x_factor: str = 'False',
-            stratify_by_stunting: str = 'False',
-            stratify_by_maternal_malnutrition: str = 'False'
-    ):
+    def __init__(self, stratify_by_wasting: str = 'wasting'):
         super().__init__()
-        self.stratifier = ResultsStratifier(
-            self.name,
-            stratify_by_wasting,
-            stratify_by_sq_lns,
-            stratify_by_wasting_treatment,
-            stratify_by_x_factor,
-            stratify_by_stunting,
-            stratify_by_maternal_malnutrition
-        )
+        self.stratifier = ResultsStratifier(self.name, by_wasting=stratify_by_wasting)
 
     @property
     def sub_components(self) -> List[ResultsStratifier]:
@@ -336,18 +317,16 @@ class DiseaseObserver(DiseaseObserver_):
             stratify_by_sq_lns: str = 'False',
             stratify_by_wasting_treatment: str = 'False',
             stratify_by_x_factor: str = 'False',
-            stratify_by_stunting: str = 'False',
-            stratify_by_maternal_malnutrition: str = 'False'
+            stratify_by_diarrhea: str = 'False',
     ):
         super().__init__(disease)
         self.stratifier = ResultsStratifier(
             self.name,
-            stratify_by_wasting,
-            stratify_by_sq_lns,
-            stratify_by_wasting_treatment,
-            stratify_by_x_factor,
-            stratify_by_stunting,
-            stratify_by_maternal_malnutrition
+            by_wasting=stratify_by_wasting,
+            by_sqlns=stratify_by_sq_lns,
+            by_wasting_treatment=stratify_by_wasting_treatment,
+            by_x_factor=stratify_by_x_factor,
+            by_diarrhea=stratify_by_diarrhea
         )
 
     @property
@@ -401,26 +380,9 @@ class DiseaseObserver(DiseaseObserver_):
 
 class CategoricalRiskObserver(CategoricalRiskObserver_):
 
-    def __init__(
-            self,
-            risk: str,
-            stratify_by_wasting: str = 'False',
-            stratify_by_sq_lns: str = 'False',
-            stratify_by_wasting_treatment: str = 'False',
-            stratify_by_x_factor: str = 'False',
-            stratify_by_stunting: str = 'False',
-            stratify_by_maternal_malnutrition: str = 'False'
-    ):
+    def __init__(self, risk: str, stratify_by_sq_lns: str = 'False',):
         super().__init__(risk)
-        self.stratifier = ResultsStratifier(
-            self.name,
-            stratify_by_wasting,
-            stratify_by_sq_lns,
-            stratify_by_wasting_treatment,
-            stratify_by_x_factor,
-            stratify_by_stunting,
-            stratify_by_maternal_malnutrition
-        )
+        self.stratifier = ResultsStratifier(self.name, by_sqlns=stratify_by_sq_lns)
 
     @property
     def sub_components(self) -> List[ResultsStratifier]:
@@ -454,26 +416,16 @@ class BirthObserver:
 
     def __init__(
             self,
-            stratify_by_wasting: str = 'False',
-            stratify_by_sq_lns: str = 'False',
-            stratify_by_wasting_treatment: str = 'False',
-            stratify_by_x_factor: str = 'False',
-            stratify_by_stunting: str = 'False',
-            stratify_by_maternal_malnutrition: str = 'True',
-            stratify_by_maternal_supplementation: str = 'True',
-            stratify_by_insecticide_treated_nets: str = 'True'
+            stratify_by_maternal_malnutrition: str = 'maternal_malnutrition',
+            stratify_by_maternal_supplementation: str = 'maternal_supplementation',
+            stratify_by_insecticide_treated_nets: str = 'insecticide_treated_nets'
     ):
         self.configuration_defaults = self._get_configuration_defaults()
         self.stratifier = ResultsStratifier(
             self.name,
-            stratify_by_wasting,
-            stratify_by_sq_lns,
-            stratify_by_wasting_treatment,
-            stratify_by_x_factor,
-            stratify_by_stunting,
-            stratify_by_maternal_malnutrition,
-            stratify_by_maternal_supplementation,
-            stratify_by_insecticide_treated_nets
+            by_maternal_malnutrition=stratify_by_maternal_malnutrition,
+            by_maternal_supplementation=stratify_by_maternal_supplementation,
+            by_insecticide_treated_nets=stratify_by_insecticide_treated_nets
         )
 
         self.tracked_column_name = 'tracked'

--- a/src/vivarium_ciff_sam/components/risk.py
+++ b/src/vivarium_ciff_sam/components/risk.py
@@ -101,6 +101,7 @@ class BirthWeightIntervention(Risk):
     def __init__(self, risk: str):
         super().__init__(risk)
         self.exposure_column_name = f'{self.risk.name}_exposure'
+        self.exposure_parameters_pipeline_name = f'{self.risk}.exposure_parameters'
 
     #################
     # Setup methods #
@@ -123,6 +124,8 @@ class BirthWeightIntervention(Risk):
         builder.population.initializes_simulants(
             self.on_initialize_simulants,
             creates_columns=[self.exposure_column_name, self.propensity_column_name],
+            requires_streams=[self._randomness_stream_name],
+            requires_values=[self.exposure_parameters_pipeline_name]
         )
 
     ########################

--- a/src/vivarium_ciff_sam/components/wasting.py
+++ b/src/vivarium_ciff_sam/components/wasting.py
@@ -1,10 +1,14 @@
-from typing import Dict, Union
+from typing import Callable, Dict, Tuple, Union
 
 import numpy as np
 import pandas as pd
 from vivarium.framework.engine import Builder
-from vivarium_public_health.risks import Risk
-from vivarium_public_health.risks.data_transformations import get_exposure_post_processor
+from vivarium.framework.lookup import LookupTable
+from vivarium_public_health.risks import Risk, RiskEffect as RiskEffect_
+from vivarium_public_health.risks.data_transformations import (
+    get_distribution_type,
+    get_exposure_post_processor
+)
 from vivarium_public_health.disease import DiseaseModel, DiseaseState, SusceptibleState
 from vivarium_public_health.utilities import EntityString
 
@@ -223,6 +227,155 @@ def ChildWasting() -> RiskModel:
         get_data_functions={'cause_specific_mortality_rate': lambda *_: 0},
         states=[severe, moderate, mild, tmrel]
     )
+
+
+class RiskEffect(RiskEffect_):
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder) -> None:
+        self.exposure_distribution_type = self._get_distribution_type(builder)
+        self.exposure = self._get_risk_exposure(builder)
+        self.relative_risk = self._get_relative_risk_source(builder)
+        self.population_attributable_fraction = self._get_population_attributable_fraction_source(
+            builder
+        )
+        self.target_modifier = self._get_target_modifier(builder)
+
+        self._register_target_modifier(builder)
+        self._register_paf_modifier(builder)
+
+    def _get_distribution_type(self, builder: Builder) -> str:
+        return get_distribution_type(builder, self.risk)
+
+    def _get_risk_exposure(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
+        return builder.value.get_value(f'{self.risk.name}.exposure')
+
+    def _get_target_modifier(self, builder: Builder) -> Callable[[pd.Index, pd.Series], pd.Series]:
+        if self.exposure_distribution_type in ['normal', 'lognormal', 'ensemble']:
+            tmred = builder.data.load(f"{self.risk}.tmred")
+            tmrel = 0.5 * (tmred["min"] + tmred["max"])
+            scale = builder.data.load(f"{self.risk}.relative_risk_scalar")
+
+            def adjust_target(index: pd.Index, target: pd.Series) -> pd.Series:
+                rr = self.relative_risk(index)
+                exposure = self.exposure(index)
+                relative_risk = np.maximum(rr.values ** ((exposure - tmrel) / scale), 1)
+                return target * relative_risk
+        else:
+            index_columns = ['index', self.risk.name]
+
+            def adjust_target(index: pd.Index, target: pd.Series) -> pd.Series:
+                rr = self.relative_risk(index)
+                exposure = self.exposure(index).reset_index()
+                exposure.columns = index_columns
+                exposure = exposure.set_index(index_columns)
+
+                relative_risk = rr.stack().reset_index()
+                relative_risk.columns = index_columns + ['value']
+                relative_risk = relative_risk.set_index(index_columns)
+
+                effect = relative_risk.loc[exposure.index, 'value'].droplevel(self.risk.name)
+                affected_rates = target * effect
+                return affected_rates
+
+        return adjust_target
+
+
+class DiarrheaRiskEffect(RiskEffect):
+    def __init__(self, target: str):
+        super(DiarrheaRiskEffect, self).__init__(f'risk_factor.{data_keys.DIARRHEA.name}', target)
+        self.diarrhea_exposure_column_name = data_keys.DIARRHEA.name
+        self.source_state, self.sink_state = self.get_source_and_sink()
+
+    def get_source_and_sink(self) -> Tuple[str, str]:
+        if self.target.measure == 'transition_rate':
+            source_state, sink_state = [
+                models.get_risk_category(state) for state in self.target.name.split('_to_')
+            ]
+        elif self.target.measure == 'incidence_rate':
+            source_state = models.get_risk_category(models.WASTING.SUSCEPTIBLE_STATE_NAME)
+            sink_state = models.get_risk_category(models.WASTING.MILD_STATE_NAME)
+        else:
+            raise ValueError(
+                f'Unsupported target measure. Supported measures are "transition_rate" and'
+                f' "incidence_rate". Provided {self.target.measure}'
+            )
+        return source_state, sink_state
+
+    def _get_distribution_type(self, builder: Builder) -> str:
+        return 'dichotomous'
+
+    def _get_risk_exposure(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
+        population_view = builder.population.get_view(
+            ['age', 'sex', self.diarrhea_exposure_column_name]
+        )
+
+        def get_exposure(index: pd.Index) -> pd.Series:
+            return population_view.get(index)[self.diarrhea_exposure_column_name]
+
+        return get_exposure
+
+    def _get_relative_risk_source(self, builder: Builder) -> LookupTable:
+        diarrhea_exposure, susceptible_exposure = load_wasting_with_diarrhea_exposure(builder)
+
+        incidence_diarrhea = load_wasting_incidence_with_diarrhea(
+            builder, self.sink_state, diarrhea_exposure, susceptible_exposure
+        )
+        incidence_susceptible = get_wasting_incidence_without_diarrhea(
+            builder, self.source_state, incidence_diarrhea
+        )
+
+        # rr_i{x}: (i_D{x} * p_S{x-1}) / (i_S{x} * p_D{x-1})
+        relative_risk = (
+            (incidence_diarrhea * susceptible_exposure.xs(self.source_state, level='wasting'))
+            / (incidence_susceptible * diarrhea_exposure.xs(self.source_state, level='wasting'))
+        ).rename(models.DIARRHEA.STATE_NAME).to_frame()
+        relative_risk[models.DIARRHEA.SUSCEPTIBLE_STATE_NAME] = 1.0
+
+        return builder.lookup.build_table(
+            relative_risk.reset_index(),
+            key_columns=['sex'],
+            parameter_columns=['age', 'year'],
+        )
+
+    def _get_population_attributable_fraction_source(self, builder: Builder) -> LookupTable:
+        # paf = (mean_rr - 1) / mean_rr
+        # mean_rr = sum_d(exposure_d|w * rr_t|d)
+        #
+        # sum_d: sum over diarrhea states d
+        # exposure_d|w: exposure of diarrhea given wasting state w = p_dw / (p_Dw + p_Sw)
+        # rr_t|d: relative risk of transition t given diarrhea state d
+
+        raw_diarrhea_exposure, raw_susceptible_exposure = (
+            load_wasting_with_diarrhea_exposure(builder)
+        )
+        raw_diarrhea_exposure = raw_diarrhea_exposure.xs(self.source_state, level='wasting')
+        raw_susceptible_exposure = raw_susceptible_exposure.xs(self.source_state, level='wasting')
+
+        rr = (
+            self.relative_risk._table.data
+            .set_index(metadata.ARTIFACT_INDEX_COLUMNS)
+            [models.DIARRHEA.STATE_NAME]
+        )
+
+        mean_rr = (
+            (raw_diarrhea_exposure * rr + raw_susceptible_exposure)
+            / (raw_diarrhea_exposure + raw_susceptible_exposure)
+        )
+
+        paf = (mean_rr - 1) / mean_rr
+        return builder.lookup.build_table(
+            paf.reset_index(),
+            key_columns=['sex'],
+            parameter_columns=['age', 'year'],
+        )
+
+    def _register_target_modifier(self, builder: Builder) -> None:
+        builder.value.register_value_modifier(
+            self.target_pipeline_name,
+            modifier=self.target_modifier,
+            requires_columns=['age', 'sex', self.diarrhea_exposure_column_name]
+        )
 
 
 # noinspection PyUnusedLocal
@@ -542,6 +695,81 @@ def get_daily_sam_treated_remission_probability(
     return t1
 
 
+def load_wasting_incidence_with_diarrhea(
+        builder: Builder,
+        sink_state: str,
+        diarrhea_exposure: pd.Series,
+        susceptible_exposure: pd.Series
+) -> pd.Series:
+
+    entrance_rate = get_entrance_rate(builder, diarrhea_exposure)
+    diarrhea_incidence = get_diarrhea_incidence(builder, susceptible_exposure)
+    diarrhea_remission = get_diarrhea_remission(builder, diarrhea_exposure)
+    diarrhea_mortality = load_mortality_with_diarrhea(builder, diarrhea_exposure)
+    sam_tx_remission = get_sam_tx_remission_with_diarrhea(builder, diarrhea_exposure)
+    sam_ux_remission = get_sam_ux_remission_with_diarrhea(builder, diarrhea_exposure)
+    mam_remission = get_mam_remission_with_diarrhea(builder, diarrhea_exposure)
+    mild_remission = get_mild_remission_with_diarrhea(builder, diarrhea_exposure)
+
+    if sink_state == data_keys.WASTING.CAT1:
+        # i_D1 = -b_D1 - di_1 + dr_1 + m_D1 + r_D1tx + r_D1ux
+        incidence = (
+            -entrance_rate.xs(data_keys.WASTING.CAT1, level='wasting')
+            - diarrhea_incidence.xs(data_keys.WASTING.CAT1, level='wasting')
+            + diarrhea_remission.xs(data_keys.WASTING.CAT1, level='wasting')
+            + diarrhea_mortality.xs(data_keys.WASTING.CAT1, level='wasting')
+            + sam_tx_remission
+            + sam_ux_remission
+        )
+    elif sink_state == data_keys.WASTING.CAT2:
+        # i_D2 = -b_D1 - b_D2 - 2.0*di_1 + dr_1 + dr_2 + m_D1 + m_D2 + r_D1tx + r_D2
+        incidence = (
+            -entrance_rate.xs(data_keys.WASTING.CAT1, level='wasting')
+            - entrance_rate.xs(data_keys.WASTING.CAT2, level='wasting')
+            - 2.0 * diarrhea_incidence.xs(data_keys.WASTING.CAT1, level='wasting')
+            + diarrhea_remission.xs(data_keys.WASTING.CAT1, level='wasting')
+            + diarrhea_remission.xs(data_keys.WASTING.CAT2, level='wasting')
+            + diarrhea_mortality.xs(data_keys.WASTING.CAT1, level='wasting')
+            + diarrhea_mortality.xs(data_keys.WASTING.CAT2, level='wasting')
+            + sam_tx_remission
+            + mam_remission
+        )
+    else:
+        # i_D3 = -b_D1 - b_D2 - b_D3 - 2.0*di_1 - di_3 + dr_1 + dr_2 + dr_3 + m_D1 + m_D2 + m_D3
+        #        + r_D3
+        incidence = (
+            -entrance_rate.xs(data_keys.WASTING.CAT1, level='wasting')
+            - entrance_rate.xs(data_keys.WASTING.CAT2, level='wasting')
+            - entrance_rate.xs(data_keys.WASTING.CAT3, level='wasting')
+            - 2.0 * diarrhea_incidence.xs(data_keys.WASTING.CAT1, level='wasting')
+            - diarrhea_incidence.xs(data_keys.WASTING.CAT3, level='wasting')
+            + diarrhea_remission.xs(data_keys.WASTING.CAT1, level='wasting')
+            + diarrhea_remission.xs(data_keys.WASTING.CAT2, level='wasting')
+            + diarrhea_remission.xs(data_keys.WASTING.CAT3, level='wasting')
+            + diarrhea_mortality.xs(data_keys.WASTING.CAT1, level='wasting')
+            + diarrhea_mortality.xs(data_keys.WASTING.CAT2, level='wasting')
+            + diarrhea_mortality.xs(data_keys.WASTING.CAT3, level='wasting')
+            + mild_remission
+        )
+    return incidence
+
+
+def get_wasting_incidence_without_diarrhea(
+        builder: Builder, source_state: str, wasting_incidence_with_diarrhea: pd.Series
+) -> pd.Series:
+
+    wasting_exposure = load_child_wasting_exposures(builder)
+    if source_state == data_keys.WASTING.CAT2:
+        incidence_rate = get_data_series(load_sam_incidence_rate(builder))
+    elif source_state == data_keys.WASTING.CAT3:
+        incidence_rate = get_data_series(load_mam_incidence_rate(builder))
+    else:
+        incidence_rate = get_data_series(load_mild_wasting_incidence_rate('', builder))
+
+    incidence = incidence_rate * wasting_exposure[source_state] - wasting_incidence_with_diarrhea
+    return incidence
+
+
 # Sub-loader functions
 
 def load_child_wasting_exposures(builder: Builder) -> pd.DataFrame:
@@ -584,11 +812,7 @@ def load_child_wasting_birth_prevalence(builder: Builder, wasting_category: str)
 
 
 def load_acmr_adjustment(builder: Builder) -> pd.Series:
-    acmr = (
-        builder.data.load(data_keys.POPULATION.ACMR)
-        .set_index(metadata.ARTIFACT_INDEX_COLUMNS)
-    )['value']
-
+    acmr = get_data_series(builder.data.load(data_keys.POPULATION.ACMR))
     adjustment = _convert_annual_rate_to_daily_probability(acmr)
     return adjustment
 
@@ -610,34 +834,21 @@ def load_daily_mortality_probabilities(builder: Builder) -> pd.DataFrame:
 
     # acmr
     # index = [ 'sex', 'age_start', 'age_end', 'year_start', 'year_end' ]
-    acmr = (
-        builder.data.load(data_keys.POPULATION.ACMR)
-        .set_index(metadata.ARTIFACT_INDEX_COLUMNS)
-    )['value']
+    acmr = get_data_series(builder.data.load(data_keys.POPULATION.ACMR))
 
     # emr_c
     # index = [ 'sex', 'age_start', 'age_end', 'year_start', 'year_end', 'affected_entity' ]
-    emr_c = pd.concat(
-        [
-            builder.data.load(c.EMR)
-            .set_index(metadata.ARTIFACT_INDEX_COLUMNS)
-            .rename(columns={'value': c.name})
-            for c in causes
-        ], axis=1
-    )
+    emr_c = pd.concat([
+        get_data_series(builder.data.load(c.EMR)).rename(c.name) for c in causes
+    ], axis=1)
     emr_c.columns.name = 'affected_entity'
     emr_c = emr_c.stack()
 
     # csmr_c
     # index = [ 'sex', 'age_start', 'age_end', 'year_start', 'year_end', 'affected_entity' ]
-    csmr_c = pd.concat(
-        [
-            builder.data.load(c.CSMR)
-            .set_index(metadata.ARTIFACT_INDEX_COLUMNS)
-            .rename(columns={'value': c.name})
-            for c in causes
-        ], axis=1
-    )
+    csmr_c = pd.concat([
+        get_data_series(builder.data.load(c.CSMR)).rename(c.name) for c in causes
+    ], axis=1)
     csmr_c.columns.name = 'affected_entity'
     csmr_c = csmr_c.stack()
 
@@ -645,9 +856,7 @@ def load_daily_mortality_probabilities(builder: Builder) -> pd.DataFrame:
     # index = [ 'sex', 'age_start', 'age_end', 'year_start', 'year_end', 'affected_entity' ]
     incidence_c = pd.concat(
         [
-            builder.data.load(c.INCIDENCE_RATE)
-            .set_index(metadata.ARTIFACT_INDEX_COLUMNS)
-            .rename(columns={'value': c.name})
+            get_data_series(builder.data.load(c.INCIDENCE_RATE)).rename(c.name)
             for c in causes if c != data_keys.PEM
         ], axis=1
     )
@@ -657,18 +866,18 @@ def load_daily_mortality_probabilities(builder: Builder) -> pd.DataFrame:
     # paf_c
     # index = [ 'sex', 'age_start', 'age_end', 'year_start', 'year_end', 'affected_entity' ]
     paf_c = (
-        builder.data.load(WASTING.PAF)
-        .set_index(metadata.ARTIFACT_INDEX_COLUMNS + ['affected_entity'])
-    )['value']
+        get_data_series(builder.data.load(WASTING.PAF))
+        .droplevel('affected_measure')
+    )
 
     # rr_ci
     # index = [
     #   'sex', 'age_start', 'age_end', 'year_start', 'year_end', 'affected_entity', 'parameter
     # ]
     rr_ci = (
-        builder.data.load(WASTING.RELATIVE_RISK)
-        .set_index(metadata.ARTIFACT_INDEX_COLUMNS + ['affected_entity', 'parameter'])
-    )['value']
+        get_data_series(builder.data.load(WASTING.RELATIVE_RISK))
+        .droplevel('affected_measure')
+    )
 
     # duration_c
     # index = [
@@ -707,7 +916,8 @@ def load_daily_mortality_probabilities(builder: Builder) -> pd.DataFrame:
             level='parameter'
         ).set_index('affected_entity', append=True)
         .reorder_levels(rr_ci.index.names)
-    )['value']
+        .squeeze()
+    )
 
     # ------------ Calculate mortality rates ------------ #
 
@@ -736,8 +946,151 @@ def load_daily_mortality_probabilities(builder: Builder) -> pd.DataFrame:
     return daily_mortality_probability
 
 
+def load_wasting_with_diarrhea_exposure(builder: Builder) -> Tuple[pd.Series, pd.Series]:
+    prev_diarrhea = get_data_series(builder.data.load(data_keys.DIARRHEA.PREVALENCE))
+    wasting_exposure = (
+        load_child_wasting_exposures(builder)
+        .rename_axis('wasting', axis=1)
+        .stack()
+    )
+
+    prevalence_ratio = (
+        data_values.WASTING.DIARRHEA_PREVALENCE_RATIO
+        .reindex(wasting_exposure.index, level='wasting')
+    )
+
+    prev_wasting_diarrhea = (
+        prevalence_ratio * wasting_exposure * prev_diarrhea
+        / ((prevalence_ratio - 1) * prev_diarrhea + 1)
+    )
+
+    prev_wasting_diarrhea[
+        prev_wasting_diarrhea.index.get_level_values('wasting') == data_keys.WASTING.CAT4
+    ] = (
+        prev_diarrhea - (
+            prev_wasting_diarrhea
+            .to_frame()
+            .query(f"wasting != '{data_keys.WASTING.CAT4}'")
+            .groupby(metadata.ARTIFACT_INDEX_COLUMNS)
+            .sum()
+            .squeeze()
+        )
+    )
+
+    prev_wasting_no_diarrhea = wasting_exposure - prev_wasting_diarrhea
+    return prev_wasting_diarrhea, prev_wasting_no_diarrhea
+
+
+def load_mortality_with_diarrhea(
+        builder: Builder, wasting_diarrhea_exposure: pd.Series
+) -> pd.Series:
+    causes = [data_keys.DIARRHEA, data_keys.MEASLES, data_keys.LRI, data_keys.PEM]
+
+    acmr = get_data_series(builder.data.load(data_keys.POPULATION.ACMR))
+    emr_pem = get_data_series(builder.data.load(data_keys.PEM.EMR))
+    emr_diarrhea = get_data_series(builder.data.load(data_keys.DIARRHEA.EMR))
+
+    csmr_c = pd.concat([
+        get_data_series(builder.data.load(c.CSMR)).rename(c.name) for c in causes
+    ], axis=1)
+    csmr_c.columns.name = 'affected_entity'
+
+    rr = (
+        get_data_series(builder.data.load(data_keys.WASTING.RELATIVE_RISK))
+        .droplevel('affected_measure')
+        .unstack('affected_entity')
+    )
+    rr.index = rr.index.set_names('wasting', level='parameter')
+
+    paf = (
+        get_data_series(builder.data.load(data_keys.WASTING.PAF))
+        .droplevel('affected_measure')
+        .unstack('affected_entity')
+    )
+
+    mortality = wasting_diarrhea_exposure * (
+        acmr
+        - (
+            csmr_c[data_keys.DIARRHEA.name]
+            + emr_diarrhea * (1 - paf[data_keys.DIARRHEA.name]) * rr[data_keys.DIARRHEA.name]
+        )
+        - csmr_c[data_keys.PEM.name] + emr_pem
+        - (
+            csmr_c[data_keys.LRI.name] * paf[data_keys.LRI.name] * rr[data_keys.LRI.name]
+        )
+        - csmr_c[data_keys.MEASLES.name] * paf[data_keys.MEASLES.name] * rr[data_keys.MEASLES.name]
+    )
+    return mortality
+
+
+def get_diarrhea_incidence(builder: Builder, wasting_no_diarrhea_exposure: pd.Series) -> pd.Series:
+    incidence_rate = get_data_series(builder.data.load(data_keys.DIARRHEA.INCIDENCE_RATE))
+    diarrhea_incidence = incidence_rate * wasting_no_diarrhea_exposure
+    return diarrhea_incidence
+
+
+def get_diarrhea_remission(builder: Builder, wasting_diarrhea_exposure: pd.Series) -> pd.Series:
+    remission_rate = get_data_series(builder.data.load(data_keys.DIARRHEA.REMISSION_RATE))
+    diarrhea_remission = remission_rate * wasting_diarrhea_exposure
+    return diarrhea_remission
+
+
+def get_entrance_rate(builder: Builder, wasting_diarrhea_exposure: pd.Series) -> pd.Series:
+    # b_Dx = ACMR * p_Dx
+    acmr = get_data_series(builder.data.load(data_keys.POPULATION.ACMR))
+    return acmr * wasting_diarrhea_exposure
+
+
+def get_sam_tx_remission_with_diarrhea(
+        builder: Builder, wasting_diarrhea_exposure: pd.Series
+) -> pd.Series:
+    remission = (
+        get_data_series(load_sam_treated_remission_rate(builder))
+        * wasting_diarrhea_exposure.xs(data_keys.WASTING.CAT1, level='wasting')
+    )
+    return remission
+
+
+def get_sam_ux_remission_with_diarrhea(
+        builder: Builder, wasting_diarrhea_exposure: pd.Series
+) -> pd.Series:
+    remission = (
+        get_data_series(load_sam_untreated_remission_rate(builder))
+        * wasting_diarrhea_exposure.xs(data_keys.WASTING.CAT1, level='wasting')
+    )
+    return remission
+
+
+def get_mam_remission_with_diarrhea(
+        builder: Builder, wasting_diarrhea_exposure: pd.Series
+) -> pd.Series:
+    remission = (
+        get_data_series(load_mam_remission_rate(builder))
+        * wasting_diarrhea_exposure.xs(data_keys.WASTING.CAT2, level='wasting')
+    )
+    return remission
+
+
+def get_mild_remission_with_diarrhea(
+        builder: Builder, wasting_diarrhea_exposure: pd.Series
+) -> pd.Series:
+    remission = (
+        get_data_series(load_mild_wasting_remission_rate('', builder))
+        * wasting_diarrhea_exposure.xs(data_keys.WASTING.CAT3, level='wasting')
+    )
+    return remission
+
+
 def adjust_exposure(exposures: pd.DataFrame, adjustment: pd.Series) -> pd.DataFrame:
     return exposures.div(1 + adjustment, axis='index')
+
+
+def get_data_series(data: pd.DataFrame) -> pd.Series:
+    return (
+        data
+        .set_index(data.columns[:-1].to_list())
+        .squeeze()
+    )
 
 
 def _get_index(builder):

--- a/src/vivarium_ciff_sam/constants/data_values.py
+++ b/src/vivarium_ciff_sam/constants/data_values.py
@@ -87,6 +87,12 @@ class __Wasting(NamedTuple):
     MAM_TX_RECOVERY_TIME_OVER_6MO: float = 41.3
     MAM_TX_RECOVERY_TIME_UNDER_6MO: float = 13.3
 
+    DIARRHEA_PREVALENCE_RATIO: pd.Series = pd.Series(
+        [1.095396, 1.085606, 1.051678],
+        index=pd.Index(['cat1', 'cat2', 'cat3'], name='wasting'),
+        name='value'
+    )
+
 
 WASTING = __Wasting()
 

--- a/src/vivarium_ciff_sam/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/branches/scenarios.yaml
@@ -1,5 +1,5 @@
 input_draw_count: 12
-random_seed_count: 100
+random_seed_count: 20
 
 branches:
   - intervention:

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -80,9 +80,9 @@ components:
             - DiseaseObserver('diarrheal_diseases', 'wasting')
             - DiseaseObserver('measles', 'wasting')
             - DiseaseObserver('lower_respiratory_infections', 'wasting')
-            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor')
-            - CategoricalRiskObserver('child_stunting', 'False', 'sq_lns')
-            - BirthObserver()
+            - DiseaseObserver('child_wasting', 'False', 'sq_lns', 'wasting_treatment', 'x_factor', 'diarrhea')
+            - CategoricalRiskObserver('child_stunting', 'sq_lns')
+            - BirthObserver('maternal_malnutrition', 'maternal_supplementation', 'insecticide_treated_nets')
 
 configuration:
     input_data:

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -107,7 +107,7 @@ configuration:
             day: 31
         step_size: 0.5 # Days
     population:
-        population_size: 1_000
+        population_size: 5_000
         age_start: 0
         age_end: 5
         exit_age: 5

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -31,6 +31,9 @@ components:
             - Mortality()
 
             - ChildWasting()
+            - DiarrheaRiskEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')
+            - DiarrheaRiskEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
+            - DiarrheaRiskEffect('risk_factor.mild_child_wasting.incidence_rate')
 
             - RiskWithTracked('risk_factor.low_birth_weight_and_short_gestation')
             - LowBirthWeight()


### PR DESCRIPTION
## Stratify Wasting by Diarrhea

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: observers
- *JIRA issue*: [MIC-2835](https://jira.ihme.washington.edu/browse/MIC-2835)
- *Research reference*: N/A

Stratify wasting by diarrhea state
Change to use 5,000 simulants per seed and 20 seeds
Refactor Observer stratification parameters to use key-word arguments to reduce verbosity.
Fix bug in dependencies of `BirthWeightIntervention` initializer.

### Verification and Testing
Ran in an interactive and verified that the model observers created the right outputs.