### PR TITLE
Bugfix/underage wasting transitions

### DIFF
--- a/src/vivarium_ciff_sam/components/wasting.py
+++ b/src/vivarium_ciff_sam/components/wasting.py
@@ -329,7 +329,9 @@ class DiarrheaRiskEffect(RiskEffect):
         relative_risk = (
             (incidence_diarrhea * susceptible_exposure.xs(self.source_state, level='wasting'))
             / (incidence_susceptible * diarrhea_exposure.xs(self.source_state, level='wasting'))
-        ).rename(models.DIARRHEA.STATE_NAME).to_frame()
+        ).rename(models.DIARRHEA.STATE_NAME)
+        relative_risk[relative_risk < 0.0] = 0.0
+        relative_risk = relative_risk.to_frame()
         relative_risk[models.DIARRHEA.SUSCEPTIBLE_STATE_NAME] = 1.0
 
         return builder.lookup.build_table(

--- a/src/vivarium_ciff_sam/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/branches/scenarios.yaml
@@ -3,5 +3,13 @@ random_seed_count: 20
 
 branches:
   - intervention:
-      scenario: ['baseline', 'wasting_treatment', 'sqlns', 'lbwsg_interventions','zinc_supplementation']
-    sam_k: ['alternative']
+      scenario: [
+        'baseline',
+        'wasting_treatment',
+        'sqlns',
+        'lbwsg_interventions',
+#        'zinc_supplementation',
+      ]
+    sam_k: [
+      'alternative',
+    ]

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -22,9 +22,9 @@ components:
 
             - RiskEffect('risk_factor.moderate_acute_malnutrition_treatment', 'risk_factor.moderate_acute_malnutrition_to_mild_child_wasting.transition_rate')
 
-            - Risk('risk_factor.therapeutic_zinc')
-            - RiskEffect('risk_factor.therapeutic_zinc', 'cause.diarrheal_diseases.remission_rate')
-            - RiskEffect('risk_factor.preventative_zinc', 'cause.diarrheal_diseases.incidence_rate')
+#            - Risk('risk_factor.therapeutic_zinc')
+#            - RiskEffect('risk_factor.therapeutic_zinc', 'cause.diarrheal_diseases.remission_rate')
+#            - RiskEffect('risk_factor.preventative_zinc', 'cause.diarrheal_diseases.incidence_rate')
 
     vivarium_ciff_sam:
         components:
@@ -71,9 +71,9 @@ components:
             - SQLNSTreatment()
             - SQLNSInterventionScaleUp()
 
-            - PreventativeZincSupplementation('risk_factor.preventative_zinc')
-            - TreatmentScaleUp('risk_factor.therapeutic_zinc')
-            - TreatmentScaleUp('risk_factor.preventative_zinc')
+#            - PreventativeZincSupplementation('risk_factor.preventative_zinc')
+#            - TreatmentScaleUp('risk_factor.therapeutic_zinc')
+#            - TreatmentScaleUp('risk_factor.preventative_zinc')
 
             - DisabilityObserver('wasting')
             - MortalityObserver('wasting')


### PR DESCRIPTION
## Fix underage wasting transitions
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-2887](https://jira.ihme.washington.edu/browse/MIC-2887)
- *Research reference*: N/A

Fix bug caused by negative relative risks in these age groups.
Comment our zinc supplementation components and scenario.

### Verification and Testing
Ran interactive sim and verified transition pipeline values looked ok.