### PR TITLE
fix results processing bug following slurm refactoring

### DIFF
--- a/src/vivarium_ciff_sam/constants/results.py
+++ b/src/vivarium_ciff_sam/constants/results.py
@@ -13,6 +13,9 @@ TOTAL_YLLS_COLUMN = 'years_of_life_lost'
 # Columns from parallel runs
 INPUT_DRAW_COLUMN = 'input_draw'
 RANDOM_SEED_COLUMN = 'random_seed'
+
+OUTPUT_INPUT_DRAW_COLUMN = 'input_data.input_draw_number'
+OUTPUT_RANDOM_SEED_COLUMN = 'randomness.random_seed'
 OUTPUT_SCENARIO_COLUMN = 'intervention.scenario'
 X_FACTOR_EFFECT_COLUMN = 'effect_of_x_factor_on_mild_child_wasting.incidence_rate.relative_risk'
 

--- a/src/vivarium_ciff_sam/results_processing/process_results.py
+++ b/src/vivarium_ciff_sam/results_processing/process_results.py
@@ -94,10 +94,17 @@ class MeasureData(NamedTuple):
 def read_data(path: Path, single_run: bool) -> (pd.DataFrame, Dict[str, Union[str, int]]):
     data = pd.read_hdf(path)
     # noinspection PyUnresolvedReferences
-    data = (data
-            .reset_index(drop=True)
-            .rename(columns={results.OUTPUT_SCENARIO_COLUMN: SCENARIO_COLUMN})
-            )
+    data = (
+        data
+        .reset_index()
+        .rename(
+            columns={
+                results.OUTPUT_SCENARIO_COLUMN: SCENARIO_COLUMN,
+                results.OUTPUT_INPUT_DRAW_COLUMN: results.INPUT_DRAW_COLUMN,
+                results.OUTPUT_RANDOM_SEED_COLUMN: results.RANDOM_SEED_COLUMN,
+            }
+        )
+    )
     if single_run:
         data[results.INPUT_DRAW_COLUMN] = 0
         data[results.RANDOM_SEED_COLUMN] = 0


### PR DESCRIPTION
## Fix results processing after vct refactor
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: post-processing
- *JIRA issue*: [MIC-2905](https://jira.ihme.washington.edu/browse/MIC-2905)
- *Research reference*: N/A

Fix results processing by renaming columns

### Verification and Testing
Ran make_results