### PR TITLE
implement birthweight effect on wasting and stunting

### DIFF
--- a/src/vivarium_ciff_sam/components/__init__.py
+++ b/src/vivarium_ciff_sam/components/__init__.py
@@ -23,6 +23,7 @@ from vivarium_ciff_sam.components.risk import (
     BEPSupplementation,
     MaternalSupplementation,
     BirthWeightIntervention,
+    BirthWeightShiftEffect,
     MaternalSupplementationType,
     PreventativeZincSupplementation,
     RiskWithTracked

--- a/src/vivarium_ciff_sam/components/risk.py
+++ b/src/vivarium_ciff_sam/components/risk.py
@@ -1,5 +1,6 @@
 from typing import Callable, Dict, List
 
+import numpy as np
 import pandas as pd
 
 from vivarium.framework.engine import Builder
@@ -7,15 +8,17 @@ from vivarium.framework.lookup import LookupTable
 from vivarium.framework.population import PopulationView, SimulantData
 from vivarium.framework.randomness import RandomnessStream
 from vivarium.framework.values import Pipeline
-from vivarium_public_health.risks import Risk, RiskEffect
+from vivarium_public_health.risks import Risk, RiskEffect as RiskEffect_
 from vivarium_public_health.risks.data_transformations import (
+    get_distribution_type,
     get_exposure_post_processor,
     pivot_categorical,
     rebin_relative_risk_data
 )
 from vivarium_public_health.risks.distributions import SimulationDistribution
 
-from vivarium_ciff_sam.constants import data_keys
+from vivarium_ciff_sam.constants import data_keys, data_values
+from vivarium_ciff_sam.utilities import get_random_variable
 
 
 class RiskWithTracked(Risk):
@@ -292,15 +295,73 @@ class PreventativeZincSupplementation(Risk):
         pass
 
 
+class RiskEffect(RiskEffect_):
+
+    def __init__(self, risk: str, target: str):
+        super().__init__(risk, target)
+        self.exposure_pipeline_name = f'{self.risk.name}.exposure'
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder) -> None:
+        self.exposure_distribution_type = self._get_distribution_type(builder)
+        self.exposure = self._get_risk_exposure(builder)
+        self.relative_risk = self._get_relative_risk_source(builder)
+        self.population_attributable_fraction = self._get_population_attributable_fraction_source(
+            builder
+        )
+        self.target_modifier = self._get_target_modifier(builder)
+
+        self._register_target_modifier(builder)
+        self._register_paf_modifier(builder)
+
+    def _get_distribution_type(self, builder: Builder) -> str:
+        return get_distribution_type(builder, self.risk)
+
+    def _get_risk_exposure(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
+        return builder.value.get_value(self.exposure_pipeline_name)
+
+    def _get_target_modifier(self, builder: Builder) -> Callable[[pd.Index, pd.Series], pd.Series]:
+        if self.exposure_distribution_type in ['normal', 'lognormal', 'ensemble']:
+            tmred = builder.data.load(f"{self.risk}.tmred")
+            tmrel = 0.5 * (tmred["min"] + tmred["max"])
+            scale = builder.data.load(f"{self.risk}.relative_risk_scalar")
+
+            def adjust_target(index: pd.Index, target: pd.Series) -> pd.Series:
+                rr = self.relative_risk(index)
+                exposure = self.exposure(index)
+                relative_risk = np.maximum(rr.values ** ((exposure - tmrel) / scale), 1)
+                return target * relative_risk
+        else:
+            index_columns = ['index', self.risk.name]
+
+            def adjust_target(index: pd.Index, target: pd.Series) -> pd.Series:
+                rr = self.relative_risk(index)
+                exposure = self.exposure(index).reset_index()
+                exposure.columns = index_columns
+                exposure = exposure.set_index(index_columns)
+
+                relative_risk = rr.stack().reset_index()
+                relative_risk.columns = index_columns + ['value']
+                relative_risk = relative_risk.set_index(index_columns)
+
+                effect = relative_risk.loc[exposure.index, 'value'].droplevel(self.risk.name)
+                affected_rates = target * effect
+                return affected_rates
+
+        return adjust_target
+
+
 class AdditiveRiskEffect(RiskEffect):
 
     def __init__(self, risk: str, target: str):
         super().__init__(risk, target)
+        self.effect_pipeline_name = f'{self.risk.name}.effect'
         self.target_risk_specific_shift_pipeline_name = f'{self.target.name}.risk_specific_shift'
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
         super().setup(builder)
+        self.effect = self._get_effect_pipeline(builder)
         self.excess_shift_source = self._get_excess_shift_source(builder)
         self.risk_specific_shift_source = self._get_risk_specific_shift_source(builder)
         self._register_risk_specific_shift_modifier(builder)
@@ -313,28 +374,12 @@ class AdditiveRiskEffect(RiskEffect):
     def _get_population_attributable_fraction_source(self, builder: Builder) -> LookupTable:
         return builder.lookup.build_table(0)
 
-    def _get_target_modifier(self, builder: Builder) -> Callable[[pd.Index, pd.Series], pd.Series]:
-        risk_exposure = builder.value.get_value(f'{self.risk.name}.exposure')
-
-        def exposure_effect(target, rr: pd.DataFrame) -> pd.Series:
-            index_columns = ['index', self.risk.name]
-
-            exposure = risk_exposure(rr.index).reset_index()
-            exposure.columns = index_columns
-            exposure = exposure.set_index(index_columns)
-
-            relative_risk = rr.stack().reset_index()
-            relative_risk.columns = index_columns + ['value']
-            relative_risk = relative_risk.set_index(index_columns)
-
-            effect = relative_risk.loc[exposure.index, 'value'].droplevel(self.risk.name)
-            affected_rates = target + effect
-            return affected_rates
-
-        def adjust_target(index: pd.Index, target: pd.Series) -> pd.Series:
-            return exposure_effect(target, self.excess_shift_source(index))
-
-        return adjust_target
+    def _get_effect_pipeline(self, builder: Builder) -> Pipeline:
+        return builder.value.register_value_producer(
+            self.effect_pipeline_name,
+            source=self.get_effect,
+            requires_values=[self.exposure_pipeline_name],
+        )
 
     def _get_excess_shift_source(self, builder: Builder) -> LookupTable:
         excess_shift_data = builder.data.load(
@@ -349,6 +394,13 @@ class AdditiveRiskEffect(RiskEffect):
             key_columns=['sex'],
             parameter_columns=['age', 'year']
         )
+
+    def _get_target_modifier(self, builder: Builder) -> Callable[[pd.Index, pd.Series], pd.Series]:
+        def adjust_target(index: pd.Index, target: pd.Series) -> pd.Series:
+            effect = self.effect(index)
+            affected_rates = target + effect
+            return affected_rates
+        return adjust_target
 
     def _get_risk_specific_shift_source(self, builder: Builder) -> LookupTable:
         risk_specific_shift_data = builder.data.load(
@@ -378,3 +430,125 @@ class AdditiveRiskEffect(RiskEffect):
 
     def risk_specific_shift_modifier(self, index: pd.Index, target: pd.Series) -> pd.Series:
         return target + self.risk_specific_shift_source(index)
+
+    def get_effect(self, index: pd.Index) -> pd.Series:
+        index_columns = ['index', self.risk.name]
+
+        excess_shift = self.excess_shift_source(index)
+        exposure = self.exposure(index).reset_index()
+        exposure.columns = index_columns
+        exposure = exposure.set_index(index_columns)
+
+        relative_risk = excess_shift.stack().reset_index()
+        relative_risk.columns = index_columns + ['value']
+        relative_risk = relative_risk.set_index(index_columns)
+
+        effect = relative_risk.loc[exposure.index, 'value'].droplevel(self.risk.name)
+        return effect
+
+
+class BirthWeightShiftEffect:
+
+    def __init__(self):
+        self.ifa_effect_pipeline_name = f'{data_keys.IFA_SUPPLEMENTATION.name}.effect'
+        self.mmn_effect_pipeline_name = f'{data_keys.MMN_SUPPLEMENTATION.name}.effect'
+        self.bep_effect_pipeline_name = f'{data_keys.BEP_SUPPLEMENTATION.name}.effect'
+        self.itn_effect_pipeline_name = f'{data_keys.INSECTICIDE_TX_NETS.name}.effect'
+
+        self.stunting_exposure_parameters_pipeline_name = (
+            f'risk_factor.{data_keys.STUNTING.name}.exposure_parameters'
+
+        )
+        self.wasting_effect_pipeline_name = 'birth_weight_shift_on_mild_wasting.effect_size'
+
+    def __repr__(self):
+        return f"BirthWeightShiftEffect()"
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self) -> str:
+        return f'birth_weight_shift_effect'
+
+    #################
+    # Setup methods #
+    #################
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder) -> None:
+        self.stunting_effect_per_gram = self._get_stunting_effect_per_gram(builder)
+
+        self.pipelines = self._get_pipelines(builder)
+        self.wasting_effect_pipeline = self._get_effect_on_wasting_exposure_pipeline(builder)
+        self._register_stunting_exposure_modifier(builder)
+
+    def _get_pipelines(self, builder: Builder) -> Dict[str, Pipeline]:
+        return {
+            pipeline_name: builder.value.get_value(pipeline_name) for pipeline_name in [
+                self.ifa_effect_pipeline_name,
+                self.mmn_effect_pipeline_name,
+                self.bep_effect_pipeline_name,
+                self.itn_effect_pipeline_name,
+            ]
+        }
+
+    def _register_stunting_exposure_modifier(self, builder: Builder) -> None:
+        builder.value.register_value_modifier(
+            self.stunting_exposure_parameters_pipeline_name,
+            modifier=self._modify_stunting_exposure_parameters,
+            requires_values=list(self.pipelines.keys()),
+        )
+
+    def _get_effect_on_wasting_exposure_pipeline(self, builder: Builder) -> Pipeline:
+        return builder.value.register_value_producer(
+            self.wasting_effect_pipeline_name,
+            source=(
+                lambda idx:
+                self._get_total_birth_weight_shift(idx) * data_values.LBWSG.WASTING_EFFECT_PER_GRAM
+            ),
+            requires_values=list(self.pipelines.keys()),
+        )
+
+    ##################################
+    # Pipeline sources and modifiers #
+    ##################################
+
+    def _modify_stunting_exposure_parameters(
+            self, index: pd.Index, target: pd.DataFrame
+    ) -> pd.DataFrame:
+        cat3_increase = self._get_total_birth_weight_shift(index) * self.stunting_effect_per_gram
+        return apply_birth_weight_effect(target, cat3_increase)
+
+    ##################
+    # Helper methods #
+    ##################
+
+    def _get_total_birth_weight_shift(self, index: pd.Index) -> pd.Series:
+        return (
+            pd.concat([pipeline(index) for pipeline in self.pipelines.values()], axis=1)
+            .sum(axis=1)
+        )
+
+    # noinspection PyMethodMayBeStatic
+    def _get_stunting_effect_per_gram(self, builder: Builder) -> float:
+        return get_random_variable(
+            builder.configuration.input_data.input_draw_number,
+            *data_values.LBWSG.STUNTING_EFFECT_PER_GRAM
+        )
+
+
+def apply_birth_weight_effect(target: pd.DataFrame, cat3_increase: pd.Series) -> pd.DataFrame:
+    sam_and_mam = target[data_keys.STUNTING.CAT1] + target[data_keys.STUNTING.CAT2]
+    apply_effect = cat3_increase < sam_and_mam
+    target.loc[apply_effect, data_keys.STUNTING.CAT3] = (
+            target[data_keys.STUNTING.CAT3] + cat3_increase
+    )
+    target.loc[apply_effect, data_keys.STUNTING.CAT2] = (
+            target[data_keys.STUNTING.CAT2] * (1 - cat3_increase / sam_and_mam)
+    )
+    target.loc[apply_effect, data_keys.STUNTING.CAT1] = (
+            target[data_keys.STUNTING.CAT1] * (1 - cat3_increase / sam_and_mam)
+    )
+    return target

--- a/src/vivarium_ciff_sam/constants/data_values.py
+++ b/src/vivarium_ciff_sam/constants/data_values.py
@@ -105,6 +105,11 @@ class __LBWSG(NamedTuple):
     TMREL_GESTATIONAL_AGE_INTERVAL: pd.Interval = pd.Interval(38.0, 42.0)
     TMREL_BIRTH_WEIGHT_INTERVAL: pd.Interval = pd.Interval(3500.0, 4500.0)
 
+    STUNTING_EFFECT_PER_GRAM: Tuple[str, stats.norm] = (
+        'stunting_effect_per_gram', stats.norm(loc=1e-04, scale=3e-05)
+    )
+    WASTING_EFFECT_PER_GRAM: float = 5.75e-05
+
 
 LBWSG = __LBWSG()
 

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -59,6 +59,8 @@ components:
             - AdditiveRiskEffect('risk_factor.insecticide_treated_nets', 'risk_factor.low_birth_weight.birth_exposure')
             - BirthweightInterventionScaleUp('risk_factor.insecticide_treated_nets')
 
+            - BirthWeightShiftEffect()
+
             - XFactorExposure()
             - XFactorEffect('risk_factor.mild_child_wasting_to_moderate_acute_malnutrition.transition_rate')
             - XFactorEffect('risk_factor.moderate_acute_malnutrition_to_severe_acute_malnutrition.transition_rate')


### PR DESCRIPTION
## Implement effect of birth-weight interventions on CGF
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: implementation
- *JIRA issue*: [MIC-2682](https://jira.ihme.washington.edu/browse/MIC-2682)
- *Research reference*: [Birth-weight intervention effect on CGF documentation](https://vivarium-research.readthedocs.io/en/latest/intervention_models/maternal_supplementation/index.html#birthweight)

Implemented the effect of a shift in birth-weight due to interventions on stunting and wasting.
- Moved refactored `RiskEffect` component from `wasting.py` to `risk.py` so it could be used by `AdditiveRiskEffect`
- Exposed the magnitude of the risk effect in `AdditiveRiskEffect` as a pipeline so that the `BirthWeightShiftEffect` component would have access to it.
- Modified stunting exposure directly with a pipeline modifier
- Modified wasting initial exposure by creating a new pipeline returning the increase in size of mild child wasting and using that inside the `get_state_weight` function of `RiskModel` which is called during simulant initialization.


### Verification and Testing
Ran simulation in InteractiveContext and verified it runs without problems and modifies the distributions of stunting and wasting. 