### PR TITLE
Add time to treatment delay

### DIFF
--- a/src/vivarium_ciff_sam/components/wasting.py
+++ b/src/vivarium_ciff_sam/components/wasting.py
@@ -450,14 +450,14 @@ def get_mild_wasting_remission_probability(
         builder: Builder, index: pd.Index, mild_child_wasting_ux_recovery_time: float
 ) -> pd.Series:
     draw = builder.configuration.input_data.input_draw_number
-    r4_under_12mo = get_random_variable(draw, *data_values.WASTING.R4_UNDER_4YR)
-    r4_under_4yr = get_random_variable(draw, *data_values.WASTING.R4_UNDER_12MO)
+    r4_over_12mo = get_random_variable(draw, *data_values.WASTING.R4_OVER_12MO)
+    r4_under_12mo = get_random_variable(draw, *data_values.WASTING.R4_UNDER_12MO)
 
     r4 = pd.Series(index=index, name='mild_wasting_remission')
-    r4[index.get_level_values('age_end') <= 4.0] = r4_under_4yr
+    r4[index.get_level_values('age_end') <= 5.0] = r4_over_12mo
     r4[index.get_level_values('age_end') <= 1.0] = r4_under_12mo
 
-    _reset_underage_transitions(r4) #TODO: what does this do?
+    _reset_underage_transitions(r4)
     return 1 - np.exp(-r4)
 
 

--- a/src/vivarium_ciff_sam/components/wasting.py
+++ b/src/vivarium_ciff_sam/components/wasting.py
@@ -405,7 +405,7 @@ def load_mild_wasting_incidence_rate(cause: str, builder: Builder) -> pd.DataFra
     )
 
     daily_probability = get_daily_mild_incidence_probability(
-        exposures, adjustment, mortality_probs, mild_wasting_ux_recovery_time
+        builder, exposures, adjustment, mortality_probs, mild_wasting_ux_recovery_time
     )
     incidence_rate = _convert_daily_probability_to_annual_rate(daily_probability)
     return incidence_rate.reset_index()
@@ -413,6 +413,7 @@ def load_mild_wasting_incidence_rate(cause: str, builder: Builder) -> pd.DataFra
 
 # noinspection DuplicatedCode
 def get_daily_mild_incidence_probability(
+        builder: Builder,
         exposures: pd.DataFrame,
         adjustment: pd.Series,
         mortality_probs: pd.DataFrame,
@@ -420,7 +421,7 @@ def get_daily_mild_incidence_probability(
 ) -> pd.Series:
     adj_exposures = adjust_exposure(exposures, adjustment)
     mild_remission_prob = get_mild_wasting_remission_probability(
-        adj_exposures[WASTING.CAT3].index, mild_wasting_ux_recovery_time
+        builder, adj_exposures[WASTING.CAT3].index, mild_wasting_ux_recovery_time
     )
 
     # i3: ap0*f4/ap4 + ap3*r4/ap4 - d4
@@ -440,21 +441,24 @@ def load_mild_wasting_remission_rate(cause: str, builder: Builder) -> pd.DataFra
         builder.configuration.child_wasting.mild_child_wasting_untreated_recovery_time
     )
 
-    daily_probability = get_mild_wasting_remission_probability(index, mild_wasting_ux_recovery_time)
+    daily_probability = get_mild_wasting_remission_probability(builder, index, mild_wasting_ux_recovery_time)
     incidence_rate = _convert_daily_probability_to_annual_rate(daily_probability)
     return incidence_rate.reset_index()
 
 
 def get_mild_wasting_remission_probability(
-        index: pd.Index, mild_child_wasting_ux_recovery_time: float
+        builder: Builder, index: pd.Index, mild_child_wasting_ux_recovery_time: float
 ) -> pd.Series:
-    r1 = pd.Series(
-        1 / mild_child_wasting_ux_recovery_time,
-        index=index,
-        name='mild_wasting_remission',
-    )
-    _reset_underage_transitions(r1)
-    return r1
+    draw = builder.configuration.input_data.input_draw_number
+    r4_under_12mo = get_random_variable(draw, *data_values.WASTING.R4_UNDER_4YR)
+    r4_under_4yr = get_random_variable(draw, *data_values.WASTING.R4_UNDER_12MO)
+
+    r4 = pd.Series(index=index, name='mild_wasting_remission')
+    r4[index.get_level_values('age_end') <= 4.0] = r4_under_4yr
+    r4[index.get_level_values('age_end') <= 1.0] = r4_under_12mo
+
+    _reset_underage_transitions(r4) #TODO: what does this do?
+    return 1 - np.exp(-r4)
 
 
 # noinspection PyUnusedLocal
@@ -480,6 +484,7 @@ def load_mam_incidence_rate(builder: Builder, *args) -> pd.DataFrame:
     mortality_probs = load_daily_mortality_probabilities(builder)
 
     daily_probability = get_daily_mam_incidence_probability(
+        builder,
         exposures,
         adjustment,
         mortality_probs,
@@ -494,6 +499,7 @@ def load_mam_incidence_rate(builder: Builder, *args) -> pd.DataFrame:
 
 # noinspection DuplicatedCode
 def get_daily_mam_incidence_probability(
+        builder: Builder,
         exposures: pd.DataFrame,
         adjustment: pd.Series,
         mortality_probs: pd.DataFrame,
@@ -507,7 +513,7 @@ def get_daily_mam_incidence_probability(
         adj_exposures.index, sam_tx_coverage, sam_tx_efficacy
     )
     mam_remission_prob = get_daily_mam_remission_probability(
-        adj_exposures.index, mam_tx_coverage, mam_tx_efficacy
+        builder, adj_exposures.index, mam_tx_coverage, mam_tx_efficacy
     )
 
     # i2: ap0*f3/ap3 + ap0*f4/ap3 + ap1*t1/ap3 + ap2*r3/ap3 - d3 - ap4*d4/ap3
@@ -530,22 +536,24 @@ def load_mam_remission_rate(builder: Builder, *args) -> float:
     mam_tx_coverage = load_wasting_treatment_coverage(builder, data_keys.WASTING.CAT2)
     mam_tx_efficacy = get_random_variable(draw, *data_values.WASTING.BASELINE_MAM_TX_EFFICACY)
 
-    daily_probability = get_daily_mam_remission_probability(index, mam_tx_coverage, mam_tx_efficacy)
+    daily_probability = get_daily_mam_remission_probability(builder, index, mam_tx_coverage, mam_tx_efficacy)
     incidence_rate = _convert_daily_probability_to_annual_rate(daily_probability)
     return incidence_rate.reset_index()
 
 
 def get_daily_mam_remission_probability(
+        builder: Builder,
         index: pd.Index,
         mam_tx_coverage: float,
         mam_tx_efficacy: float
 ) -> pd.Series:
+    draw = builder.configuration.input_data.input_draw_number
     mam_tx_recovery_time = pd.Series(index=index, name='mam_remission')
     mam_tx_recovery_time[index.get_level_values('age_start') < 0.5] = (
         data_values.WASTING.MAM_TX_RECOVERY_TIME_UNDER_6MO
     )
     mam_tx_recovery_time[0.5 <= index.get_level_values('age_start')] = (
-        data_values.WASTING.MAM_TX_RECOVERY_TIME_OVER_6MO
+        get_random_variable(draw, *data_values.WASTING.MAM_TX_RECOVERY_TIME_OVER_6MO)
     )
     mam_tx_eff_coverage = mam_tx_coverage * mam_tx_efficacy
 
@@ -554,7 +562,7 @@ def get_daily_mam_remission_probability(
     annual_remission_rate = (
         mam_tx_eff_coverage * metadata.YEAR_DURATION / mam_tx_recovery_time
         + ((1 - mam_tx_eff_coverage) * metadata.YEAR_DURATION
-           / data_values.WASTING.MAM_UX_RECOVERY_TIME)
+           / data_values.WASTING.MAM_UX_RECOVERY_TIME_OVER_6MO)
     )
     r3 = _convert_annual_rate_to_daily_probability(annual_remission_rate)
     _reset_underage_transitions(r3)

--- a/src/vivarium_ciff_sam/constants/data_values.py
+++ b/src/vivarium_ciff_sam/constants/data_values.py
@@ -103,8 +103,8 @@ class __Wasting(NamedTuple):
         )
     )
 
-    R4_UNDER_4YR: Tuple = (
-        'r4_under_4yr', get_truncnorm_from_sd(
+    R4_OVER_12MO: Tuple = (
+        'r4_over_12mo', get_truncnorm_from_sd(
             mean=0.005043, sd=0.002428
         )
     )

--- a/src/vivarium_ciff_sam/constants/data_values.py
+++ b/src/vivarium_ciff_sam/constants/data_values.py
@@ -83,8 +83,7 @@ class __Wasting(NamedTuple):
 
     # Treated time to recovery in days
     SAM_TX_RECOVERY_TIME_OVER_6MO: float = 62.3 # 48.3 + 14
-    SAM_TX_RECOVERY_TIME_UNDER_6MO: float = 13.3
-    MAM_TX_RECOVERY_TIME_OVER_6MO: Tuple = ( #TODO: make sure this is now being used correctly
+    MAM_TX_RECOVERY_TIME_OVER_6MO: Tuple = (
         'mam_tx_recovery_time_over_6mo', get_norm_from_quantiles(
             mean=55.3, lower=48.4, upper=63.0
         )

--- a/src/vivarium_ciff_sam/constants/data_values.py
+++ b/src/vivarium_ciff_sam/constants/data_values.py
@@ -78,19 +78,35 @@ class __Wasting(NamedTuple):
     )
 
     # Untreated time to recovery in days
-    MAM_UX_RECOVERY_TIME: float = 63.0
+    MAM_UX_RECOVERY_TIME_OVER_6MO: float = 147.0
     DEFAULT_MILD_WASTING_UX_RECOVERY_TIME: float = 1_000.0
 
     # Treated time to recovery in days
-    SAM_TX_RECOVERY_TIME_OVER_6MO: float = 48.3
+    SAM_TX_RECOVERY_TIME_OVER_6MO: float = 62.3 # 48.3 + 14
     SAM_TX_RECOVERY_TIME_UNDER_6MO: float = 13.3
-    MAM_TX_RECOVERY_TIME_OVER_6MO: float = 41.3
+    MAM_TX_RECOVERY_TIME_OVER_6MO: Tuple = ( #TODO: make sure this is now being used correctly
+        'mam_tx_recovery_time_over_6mo', get_norm_from_quantiles(
+            mean=55.3, lower=48.4, upper=63.0
+        )
+    )
     MAM_TX_RECOVERY_TIME_UNDER_6MO: float = 13.3
 
     DIARRHEA_PREVALENCE_RATIO: pd.Series = pd.Series(
         [1.095396, 1.085606, 1.051678],
         index=pd.Index(['cat1', 'cat2', 'cat3'], name='wasting'),
         name='value'
+    )
+
+    R4_UNDER_12MO: Tuple = (
+        'r4_under_12mo', get_truncnorm_from_sd(
+            mean=0.006140, sd=0.003015,
+        )
+    )
+
+    R4_UNDER_4YR: Tuple = (
+        'r4_under_4yr', get_truncnorm_from_sd(
+            mean=0.005043, sd=0.002428
+        )
     )
 
 
@@ -205,7 +221,7 @@ class __InsecticideTreatedNets(NamedTuple):
 
     BIRTH_WEIGHT_SHIFT: Tuple = (
         'insecticide_treated_nets_effect_on_birth_weight',
-        get_norm_from_quantiles(mean=33, lower=5, upper=62, quantiles=(0.05, 0.95))
+        get_norm_from_quantiles(mean=33, lower=5, upper=62)
     )
 
     PROP_MALARIOUS: float = 0.6
@@ -229,12 +245,12 @@ class __ZincSupplementation(NamedTuple):
 
     PREVENTATIVE_TX_EFFICACY: Tuple[str, stats.truncnorm] = (
         'preventative_zinc_treatment_efficacy',
-        get_lognorm_from_quantiles(median=0.89, lower=0.82, upper=0.97, quantiles=(0.05, 0.95))
+        get_lognorm_from_quantiles(median=0.89, lower=0.82, upper=0.97)
     )
 
     DIARRHEA_DURATION_SHIFT_HOURS: Tuple[str, stats.norm] = (
         'diarrhea_duration_shift',
-        get_norm_from_quantiles(mean=-11.46, lower=-19.72, upper=-3.19, quantiles=(0.05, 0.95))
+        get_norm_from_quantiles(mean=-11.46, lower=-19.72, upper=-3.19)
     )
 
 

--- a/src/vivarium_ciff_sam/data/loader.py
+++ b/src/vivarium_ciff_sam/data/loader.py
@@ -597,10 +597,14 @@ def load_mam_treatment_rr(key: str, location: str) -> pd.DataFrame:
     mam_tx_efficacy, mam_tx_efficacy_tmrel = utilities.get_treatment_efficacy(demography, data_keys.WASTING.CAT2)
     index = mam_tx_efficacy.index
 
-    mam_ux_duration = data_values.WASTING.MAM_UX_RECOVERY_TIME
+    mam_ux_duration = data_values.WASTING.MAM_UX_RECOVERY_TIME_OVER_6MO
     mam_tx_duration = pd.Series(index=index)
     mam_tx_duration[index.get_level_values('age_start') < 0.5] = data_values.WASTING.MAM_TX_RECOVERY_TIME_UNDER_6MO
-    mam_tx_duration[0.5 <= index.get_level_values('age_start')] = data_values.WASTING.MAM_TX_RECOVERY_TIME_OVER_6MO
+    mam_tx_duration[0.5 <= index.get_level_values('age_start')] = (
+        get_random_variable_draws(
+            mam_tx_duration[0.5 <= index.get_level_values('age_start')].index,
+            *data_values.WASTING.MAM_TX_RECOVERY_TIME_OVER_6MO)
+    )
     mam_tx_duration = (
         pd.DataFrame({f'draw_{i}': 1 for i in range(0, 1000)}, index=index)
         .multiply(mam_tx_duration, axis='index')

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -114,9 +114,9 @@ configuration:
 
     intervention:
         scenario: 'baseline'
-
-    child_wasting:
-        mild_child_wasting_untreated_recovery_time: 30
+#
+#    child_wasting:
+#        mild_child_wasting_untreated_recovery_time: 30
 
     x_factor:
         exposure: 0.5

--- a/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
+++ b/src/vivarium_ciff_sam/model_specifications/ciff_sam.yaml
@@ -114,9 +114,6 @@ configuration:
 
     intervention:
         scenario: 'baseline'
-#
-#    child_wasting:
-#        mild_child_wasting_untreated_recovery_time: 30
 
     x_factor:
         exposure: 0.5


### PR DESCRIPTION
## Add time to treatment delay
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
Add time to wasting treatment delay by updating wasting transition data values
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: [MIC-2889](https://jira.ihme.washington.edu/browse/MIC-2889) 
- *Research reference*: This [PR](https://github.com/ihmeuw/vivarium_research/pull/783/files#diff-91ae1cae3a99a0493ca4be868bc068d7e1d3f1d832adaec7aece32bcb613677f) and this [PR](https://github.com/ihmeuw/vivarium_research/pull/789/files)

- Updated r4 (mild wasting to susceptible daily probability)
- Updated untreated mam recovery time
- Updated treated mam recovery time
- Updated SAM treated recovery time

### Verification and Testing
In an interactive sim, checked that pipelines corresponding to mam, sam, mild remission had reasonable values when all components that change baseline values were removed.